### PR TITLE
ci(go): add golangci-lint, update download-syft action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -67,3 +67,22 @@ jobs:
 
       - name: "Test"
         run: go test ./...
+
+  lint:
+    name: "Lint"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: "Setup Go ${{ env.GO_VERSION }}"
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+          cache: true
+          check-latest: true
+
+      - name: "Run golangci-lint"
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409 # v3.7.0
 
       - name: "Install Syft"
-        uses: anchore/sbom-action/download-syft@1ca97d9028b51809cf6d3c934c3e160716e1b605 # v0.17.5
+        uses: anchore/sbom-action/download-syft@251a468eed47e5082b105c3ba6ee500c0e65a764 # v0.17.6
 
       - name: "Setup QEMU"
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
 linters:
   enable:
     - bodyclose
-    - exportloopref
+    - copyloopvar
     - gofumpt
     - goheader
     - goimports


### PR DESCRIPTION
- Add `lint` job to the `go.yml` workflow, which runs `golangci-lint`.
- Update `anchore/sbom-action/download-syft` action to v0.17.6 (`251a468eed47e5082b105c3ba6ee500c0e65a764`).

Additionally, replace deprecated `exportloopref` linter (issue fixed in Go 1.22) with `copyloopvar`