### PR TITLE
exporter: deduplicate and simplify descs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The following metrics are exposed by this exporter:
 
 | Metric name                                            | Description                                                                   |
 |--------------------------------------------------------|-------------------------------------------------------------------------------|
-| `starlink_up`                                          | Whether scraping metrics from the Starlink dish was successful                |
 | `starlink_exporter_scrapes_total`                      | Total number of Starlink dish scrapes                                         |
 | `starlink_exporter_scrape_duration_seconds`            | Time taken to scrape metrics from the Starlink dish                           |
+| `starlink_dish_up`                                     | Whether scraping metrics from the Starlink dish was successful                |
 | `starlink_dish_info`                                   | Starlink dish software information                                            |
 | `starlink_dish_uptime_seconds`                         | Starlink dish uptime in seconds                                               |
 | `starlink_dish_snr_above_noise_floor`                  | Whether Starlink dish signal-to-noise ratio is above noise floor              |

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -1,0 +1,231 @@
+package exporter
+
+import "github.com/prometheus/client_golang/prometheus"
+
+const (
+	namespace         = "starlink"
+	dishSubsystem     = "dish"
+	exporterSubsystem = "exporter"
+)
+
+var (
+	// Exporter
+	dishUp = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "up",
+		Help:      "Whether scraping metrics from the Starlink dish was successful",
+	}
+	exporterScrapesTotal = Desc{
+		Namespace: namespace,
+		Subsystem: exporterSubsystem,
+		Name:      "scrapes_total",
+		Help:      "Total number of Starlink dish scrapes",
+	}
+	exporterScrapeDurationSeconds = Desc{
+		Namespace: namespace,
+		Subsystem: exporterSubsystem,
+		Name:      "scrape_duration_seconds",
+		Help:      "Time taken to scrape metrics from the Starlink dish",
+	}
+
+	// Informational
+	dishInfo = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "info",
+		Help:      "Starlink dish software information",
+		Labels: []string{
+			"device_id",
+			"hardware_version",
+			"board_rev",
+			"software_version",
+			"manufactured_version",
+			"generation_number",
+			"country_code",
+			"utc_offset",
+			"boot_count",
+		},
+	}
+	dishUptimeSeconds = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "uptime_seconds",
+		Help:      "Starlink dish uptime in seconds",
+	}
+
+	// Signal-to-noise ratio
+	dishSnrAboveNoiseFloor = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "snr_above_noise_floor",
+		Help:      "Whether Starlink dish signal-to-noise ratio is above noise floor",
+	}
+	dishSnrPersistentlyLow = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "snr_persistently_low",
+		Help:      "Whether Starlink dish signal-to-noise ratio is persistently low",
+	}
+
+	// Throughput
+	dishUplinkThroughputBps = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "uplink_throughput_bps",
+		Help:      "Starlink dish uplink throughput in bits/sec",
+	}
+	dishDownlinkThroughputBps = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "downlink_throughput_bps",
+		Help:      "Starlink dish downlink throughput in bit/sec",
+	}
+	dishDownlinkThroughputHistogram = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "downlink_throughput_bps_histogram",
+		Help:      "Histogram of Starlink dish downlink throughput over last 15 minutes",
+	}
+	dishUplinkThroughputHistogram = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "uplink_throughput_bps_histogram",
+		Help:      "Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes",
+	}
+
+	// PoP ping
+	dishPopPingDropRatio = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "pop_ping_drop_ratio",
+		Help:      "Starlink PoP ping drop ratio",
+	}
+	dishPopPingLatencySeconds = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "pop_ping_latency_seconds",
+		Help:      "Starlink PoP ping latency in seconds",
+	}
+	dishPopPingLatencyHistogram = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "pop_ping_latency_seconds_histogram",
+		Help:      "Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes",
+	}
+
+	// Power In
+	dishPowerInputHistogram = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "power_input_watts_histogram",
+		Help:      "Histogram of Starlink dish power input in watts over last 15 minutes",
+	}
+	dishPowerInput = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "power_input_watts",
+		Help:      "Current power input for the Starlink dish",
+	}
+
+	// Software update
+	dishSoftwareUpdateState = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "software_update_state",
+		Help:      "Starlink dish update state",
+	}
+	dishSoftwareUpdateRebootReady = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "software_update_reboot_ready",
+		Help:      "Whether the Starlink dish is ready to reboot to apply a software update",
+	}
+
+	// Boresight
+	dishBoresightAzimuthDeg = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "boresight_azimuth_deg",
+		Help:      "Starlink dish boresight azimuth in degrees",
+	}
+	dishBoresightElevationDeg = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "boresight_elevation_deg",
+		Help:      "Starlink dish boresight elevation in degrees",
+	}
+
+	// Obstruction
+	dishCurrentlyObstructed = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "currently_obstructed",
+		Help:      "Whether the Starlink dish is currently obstructed",
+	}
+	dishFractionObstructionRatio = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "fraction_obstruction_ratio",
+		Help:      "Fraction of Starlink dish that is obstructed",
+	}
+	dishLast24HoursObstructedSeconds = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "last_24h_obstructed_seconds",
+		Help:      "Number of seconds the Starlink dish was obstructed in the past 24 hours",
+	}
+	dishProlongedObstructionDurationSeconds = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "prolonged_obstruction_duration_seconds",
+		Help:      "Average prolonged obstruction duration in seconds",
+	}
+)
+
+var Descs = []Desc{
+	exporterScrapesTotal,
+	exporterScrapeDurationSeconds,
+	dishUp,
+	dishInfo,
+	dishUptimeSeconds,
+	dishSnrAboveNoiseFloor,
+	dishSnrPersistentlyLow,
+	dishUplinkThroughputBps,
+	dishDownlinkThroughputBps,
+	dishDownlinkThroughputHistogram,
+	dishUplinkThroughputHistogram,
+	dishPopPingDropRatio,
+	dishPopPingLatencySeconds,
+	dishPopPingLatencyHistogram,
+	dishSoftwareUpdateRebootReady,
+	dishBoresightAzimuthDeg,
+	dishBoresightElevationDeg,
+	dishCurrentlyObstructed,
+	dishFractionObstructionRatio,
+	dishLast24HoursObstructedSeconds,
+	dishProlongedObstructionDurationSeconds,
+	dishPowerInputHistogram,
+	dishPowerInput,
+}
+
+type Desc struct {
+	Namespace   string
+	Subsystem   string
+	Name        string
+	Help        string
+	Labels      []string
+	ConstLabels prometheus.Labels
+	desc        *prometheus.Desc
+}
+
+func (d Desc) FQName() string {
+	return prometheus.BuildFQName(d.Namespace, d.Subsystem, d.Name)
+}
+
+func (d Desc) Desc() *prometheus.Desc {
+	if d.desc == nil {
+		d.desc = prometheus.NewDesc(d.FQName(), d.Help, d.Labels, d.ConstLabels)
+	}
+	return d.desc
+}

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2024 Joshua Sing <joshua@joshuasing.dev>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package exporter
 
 import "github.com/prometheus/client_golang/prometheus"
@@ -10,12 +30,6 @@ const (
 
 var (
 	// Exporter
-	dishUp = Desc{
-		Namespace: namespace,
-		Subsystem: dishSubsystem,
-		Name:      "up",
-		Help:      "Whether scraping metrics from the Starlink dish was successful",
-	}
 	exporterScrapesTotal = Desc{
 		Namespace: namespace,
 		Subsystem: exporterSubsystem,
@@ -30,6 +44,12 @@ var (
 	}
 
 	// Informational
+	dishUp = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "up",
+		Help:      "Whether scraping metrics from the Starlink dish was successful",
+	}
 	dishInfo = Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -33,142 +33,7 @@ import (
 	"github.com/joshuasing/starlink_exporter/internal/spacex/api/device"
 )
 
-const (
-	namespace         = "starlink"
-	dishSubsystem     = "dish"
-	exporterSubsystem = "exporter"
-)
-
 const DefaultDishAddress = "192.168.100.1:9200"
-
-var (
-	// Informational
-	dishInfo = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "info"),
-		"Starlink dish software information",
-		[]string{
-			"device_id",
-			"hardware_version",
-			"board_rev",
-			"software_version",
-			"manufactured_version",
-			"generation_number",
-			"country_code",
-			"utc_offset",
-			"boot_count",
-		}, nil,
-	)
-	dishUptimeSeconds = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "uptime_seconds"),
-		"Starlink dish uptime in seconds",
-		nil, nil,
-	)
-
-	// Signal-to-noise ratio
-	dishSnrAboveNoiseFloor = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "snr_above_noise_floor"),
-		"Whether Starlink dish signal-to-noise ratio is above noise floor",
-		nil, nil,
-	)
-	dishSnrPersistentlyLow = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "snr_persistently_low"),
-		"Whether Starlink dish signal-to-noise ratio is persistently low",
-		nil, nil,
-	)
-
-	// Throughput
-	dishUplinkThroughputBps = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "uplink_throughput_bps"),
-		"Starlink dish uplink throughput in bits/sec",
-		nil, nil,
-	)
-	dishDownlinkThroughputBps = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "downlink_throughput_bps"),
-		"Starlink dish downlink throughput in bit/sec",
-		nil, nil,
-	)
-	dishDownlinkThroughputHistogram = prometheus.NewDesc(
-		dishDownlinkThroughputHistOpts.Name, dishDownlinkThroughputHistOpts.Help,
-		nil, nil,
-	)
-	dishUplinkThroughputHistogram = prometheus.NewDesc(
-		dishUplinkThroughputHistOpts.Name, dishUplinkThroughputHistOpts.Help,
-		nil, nil,
-	)
-
-	// PoP ping
-	dishPopPingDropRatio = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "pop_ping_drop_ratio"),
-		"Starlink PoP ping drop ratio",
-		nil, nil,
-	)
-	dishPopPingLatencySeconds = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "pop_ping_latency_seconds"),
-		"Starlink PoP ping latency in seconds",
-		nil, nil,
-	)
-	dishPopPingLatencyHistogram = prometheus.NewDesc(
-		dishPopPingLatencyHistOpts.Name, dishPopPingLatencyHistOpts.Help,
-		nil, nil,
-	)
-
-	// Power In
-	dishPowerInputHistogram = prometheus.NewDesc(
-		dishPowerInputHistOpts.Name, dishPowerInputHistOpts.Help,
-		nil, nil,
-	)
-	dishPowerInput = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "power_input_watts"),
-		"Current power input for the Starlink dish",
-		nil, nil,
-	)
-
-	// Software update
-	dishSoftwareUpdateState = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "software_update_state"),
-		"Starlink dish update state",
-		nil, nil,
-	)
-	dishSoftwareUpdateRebootReady = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "software_update_reboot_ready"),
-		"Whether the Starlink dish is ready to reboot to apply a software update",
-		nil, nil,
-	)
-
-	// Boresight
-	dishBoresightAzimuthDeg = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "boresight_azimuth_deg"),
-		"Starlink dish boresight azimuth in degrees",
-		nil, nil,
-	)
-	dishBoresightElevationDeg = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "boresight_elevation_deg"),
-		"Starlink dish boresight elevation in degrees",
-		nil, nil,
-	)
-
-	// Obstruction
-	dishCurrentlyObstructed = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "currently_obstructed"),
-		"Whether the Starlink dish is currently obstructed",
-		nil, nil,
-	)
-	dishFractionObstructionRatio = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "fraction_obstruction_ratio"),
-		"Fraction of Starlink dish that is obstructed",
-		nil, nil,
-	)
-	dishLast24HoursObstructedSeconds = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "last_24h_obstructed_seconds"),
-		"Number of seconds the Starlink dish was obstructed in the past 24 hours",
-		nil, nil,
-	)
-	dishProlongedObstructionDurationSeconds = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, dishSubsystem, "prolonged_obstruction_duration_seconds"),
-		"Average prolonged obstruction duration in seconds",
-		nil, nil,
-	)
-)
 
 // Exporter is a Starlink Dishy metrics exporter.
 type Exporter struct {
@@ -176,7 +41,7 @@ type Exporter struct {
 	conn   *grpc.ClientConn    // Starlink Dishy gRPC connection
 	client device.DeviceClient // Starlink Dishy gRPC client
 
-	up                    prometheus.Gauge   // starlink_up
+	up                    prometheus.Gauge   // starlink_dish_up
 	totalScrapes          prometheus.Counter // starlink_exporter_scrapes_total
 	scrapeDurationSeconds prometheus.Gauge   // starlink_exporter_scrape_duration_seconds
 }
@@ -197,22 +62,16 @@ func NewExporter(address string) (*Exporter, error) {
 		conn:   conn,
 		client: client,
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: dishSubsystem,
-			Name:      "up",
-			Help:      "Whether scraping metrics from the Starlink dish was successful",
+			Name: dishUp.FQName(),
+			Help: dishUp.Help,
 		}),
 		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: exporterSubsystem,
-			Name:      "scrapes_total",
-			Help:      "Total number of Starlink dish scrapes",
+			Name: exporterScrapesTotal.FQName(),
+			Help: exporterScrapesTotal.Help,
 		}),
 		scrapeDurationSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: exporterSubsystem,
-			Name:      "scrape_duration_seconds",
-			Help:      "Time taken to scrape metrics from the Starlink dish",
+			Name: exporterScrapeDurationSeconds.FQName(),
+			Help: exporterScrapeDurationSeconds.Help,
 		}),
 	}, nil
 }
@@ -223,31 +82,9 @@ func (e *Exporter) ConnState() connectivity.State {
 }
 
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- e.up.Desc()
-	ch <- e.totalScrapes.Desc()
-	ch <- e.scrapeDurationSeconds.Desc()
-
-	// Scraped by scrapeDishStatus
-	ch <- dishInfo
-	ch <- dishUptimeSeconds
-	ch <- dishSnrAboveNoiseFloor
-	ch <- dishSnrPersistentlyLow
-	ch <- dishUplinkThroughputBps
-	ch <- dishDownlinkThroughputBps
-	ch <- dishDownlinkThroughputHistogram
-	ch <- dishUplinkThroughputHistogram
-	ch <- dishPopPingDropRatio
-	ch <- dishPopPingLatencySeconds
-	ch <- dishPopPingLatencyHistogram
-	ch <- dishSoftwareUpdateRebootReady
-	ch <- dishBoresightAzimuthDeg
-	ch <- dishBoresightElevationDeg
-	ch <- dishCurrentlyObstructed
-	ch <- dishFractionObstructionRatio
-	ch <- dishLast24HoursObstructedSeconds
-	ch <- dishProlongedObstructionDurationSeconds
-	ch <- dishPowerInputHistogram
-	ch <- dishPowerInput
+	for _, d := range Descs {
+		ch <- d.Desc()
+	}
 }
 
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -33,26 +33,23 @@ import (
 
 var (
 	dishPopPingLatencyHistOpts = prometheus.HistogramOpts{
-		Name:    prometheus.BuildFQName(namespace, dishSubsystem, "pop_ping_latency_seconds_histogram"),
-		Help:    "Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes",
+		Name:    dishPopPingLatencyHistogram.FQName(),
+		Help:    dishPopPingLatencyHistogram.Help,
 		Buckets: []float64{0.01, 0.02, 0.021, 0.022, 0.023, 0.024, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 	}
-
 	dishDownlinkThroughputHistOpts = prometheus.HistogramOpts{
-		Name:    prometheus.BuildFQName(namespace, dishSubsystem, "downlink_throughput_bps_histogram"),
-		Help:    "Histogram of Starlink dish downlink throughput over last 15 minutes",
+		Name:    dishDownlinkThroughputHistogram.FQName(),
+		Help:    dishDownlinkThroughputHistogram.Help,
 		Buckets: []float64{1e6, 5e6, 10e6, 25e6, 50e6, 100e6, 250e6, 500e6},
 	}
-
 	dishUplinkThroughputHistOpts = prometheus.HistogramOpts{
-		Name:    prometheus.BuildFQName(namespace, dishSubsystem, "uplink_throughput_bps_histogram"),
-		Help:    "Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes",
+		Name:    dishUplinkThroughputHistogram.FQName(),
+		Help:    dishUplinkThroughputHistogram.Help,
 		Buckets: []float64{1e6, 5e6, 10e6, 25e6, 50e6, 100e6, 250e6, 500e6},
 	}
-
 	dishPowerInputHistOpts = prometheus.HistogramOpts{
-		Name:    prometheus.BuildFQName(namespace, dishSubsystem, "power_input_watts_histogram"),
-		Help:    "Histogram of Starlink dish power input in watts over last 15 minutes",
+		Name:    dishPowerInputHistogram.FQName(),
+		Help:    dishPowerInputHistogram.Help,
 		Buckets: []float64{20, 25, 30, 40, 50, 75, 100, 150, 200},
 	}
 )
@@ -117,7 +114,7 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 
 	// starlink_dish_info
 	ch <- prometheus.MustNewConstMetric(
-		dishInfo, prometheus.GaugeValue, 1,
+		dishInfo.Desc(), prometheus.GaugeValue, 1,
 		deviceInfo.GetId(),
 		deviceInfo.GetHardwareVersion(),
 		itos(deviceInfo.GetBoardRev()),
@@ -131,73 +128,73 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 
 	// starlink_dish_uptime_seconds
 	ch <- prometheus.MustNewConstMetric(
-		dishUptimeSeconds, prometheus.GaugeValue,
+		dishUptimeSeconds.Desc(), prometheus.GaugeValue,
 		float64(deviceState.GetUptimeS()),
 	)
 
 	// starlink_dish_snr_above_noise_floor
 	ch <- prometheus.MustNewConstMetric(
-		dishSnrAboveNoiseFloor, prometheus.GaugeValue,
+		dishSnrAboveNoiseFloor.Desc(), prometheus.GaugeValue,
 		btof(dishStatus.GetIsSnrAboveNoiseFloor()),
 	)
 
 	// starlink_dish_snr_persistently_low
 	ch <- prometheus.MustNewConstMetric(
-		dishSnrPersistentlyLow, prometheus.GaugeValue,
+		dishSnrPersistentlyLow.Desc(), prometheus.GaugeValue,
 		btof(dishStatus.GetIsSnrPersistentlyLow()),
 	)
 
 	// starlink_dish_pop_ping_drop_ratio
 	ch <- prometheus.MustNewConstMetric(
-		dishPopPingDropRatio, prometheus.GaugeValue,
+		dishPopPingDropRatio.Desc(), prometheus.GaugeValue,
 		float64(dishStatus.GetPopPingDropRate()),
 	)
 
 	// starlink_dish_software_update_state
 	ch <- prometheus.MustNewConstMetric(
-		dishSoftwareUpdateState, prometheus.GaugeValue,
+		dishSoftwareUpdateState.Desc(), prometheus.GaugeValue,
 		float64(dishStatus.GetSoftwareUpdateState()),
 	)
 
 	// starlink_dish_software_update_reboot_ready
 	ch <- prometheus.MustNewConstMetric(
-		dishSoftwareUpdateRebootReady, prometheus.GaugeValue,
+		dishSoftwareUpdateRebootReady.Desc(), prometheus.GaugeValue,
 		btof(dishStatus.GetSwupdateRebootReady()),
 	)
 
 	// starlink_dish_boresight_azimuth_deg
 	ch <- prometheus.MustNewConstMetric(
-		dishBoresightAzimuthDeg, prometheus.GaugeValue,
+		dishBoresightAzimuthDeg.Desc(), prometheus.GaugeValue,
 		float64(dishStatus.GetBoresightAzimuthDeg()),
 	)
 
 	// starlink_dish_boresight_elevation_deg
 	ch <- prometheus.MustNewConstMetric(
-		dishBoresightElevationDeg, prometheus.GaugeValue,
+		dishBoresightElevationDeg.Desc(), prometheus.GaugeValue,
 		float64(dishStatus.GetBoresightElevationDeg()),
 	)
 
 	// starlink_dish_currently_obstructed
 	ch <- prometheus.MustNewConstMetric(
-		dishCurrentlyObstructed, prometheus.GaugeValue,
+		dishCurrentlyObstructed.Desc(), prometheus.GaugeValue,
 		btof(obstructionStats.GetCurrentlyObstructed()),
 	)
 
 	// starlink_dish_fraction_obstruction_ratio
 	ch <- prometheus.MustNewConstMetric(
-		dishFractionObstructionRatio, prometheus.GaugeValue,
+		dishFractionObstructionRatio.Desc(), prometheus.GaugeValue,
 		float64(obstructionStats.GetFractionObstructed()),
 	)
 
 	// starlink_dish_last_24h_obstructed_seconds
 	ch <- prometheus.MustNewConstMetric(
-		dishLast24HoursObstructedSeconds, prometheus.GaugeValue,
+		dishLast24HoursObstructedSeconds.Desc(), prometheus.GaugeValue,
 		float64(obstructionStats.GetTimeObstructed()),
 	)
 
 	// starlink_dish_prolonged_obstruction_duration_seconds
 	ch <- prometheus.MustNewConstMetric(
-		dishProlongedObstructionDurationSeconds, prometheus.GaugeValue,
+		dishProlongedObstructionDurationSeconds.Desc(), prometheus.GaugeValue,
 		float64(obstructionStats.GetAvgProlongedObstructionDurationS()),
 	)
 
@@ -225,7 +222,7 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 
 	// starlink_dish_pop_ping_latency_seconds
 	ch <- prometheus.MustNewConstMetric(
-		dishPopPingLatencySeconds, prometheus.GaugeValue,
+		dishPopPingLatencySeconds.Desc(), prometheus.GaugeValue,
 		float64(latencyData[len(latencyData)-1]/1000),
 	)
 
@@ -240,7 +237,7 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 	// starlink_dish_downlink_throughput_bps
 	if len(downlinkData) > 0 {
 		ch <- prometheus.MustNewConstMetric(
-			dishDownlinkThroughputBps, prometheus.GaugeValue,
+			dishDownlinkThroughputBps.Desc(), prometheus.GaugeValue,
 			float64(downlinkData[len(downlinkData)-1]),
 		)
 	}
@@ -256,7 +253,7 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 	// starlink_dish_uplink_throughput_bps
 	if len(uplinkData) > 0 {
 		ch <- prometheus.MustNewConstMetric(
-			dishUplinkThroughputBps, prometheus.GaugeValue,
+			dishUplinkThroughputBps.Desc(), prometheus.GaugeValue,
 			float64(uplinkData[len(uplinkData)-1]),
 		)
 	}
@@ -272,7 +269,7 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 	// starlink_dish_power_input_watts
 	if len(powerData) > 0 {
 		ch <- prometheus.MustNewConstMetric(
-			dishPowerInput, prometheus.GaugeValue,
+			dishPowerInput.Desc(), prometheus.GaugeValue,
 			float64(powerData[len(powerData)-1]),
 		)
 	}


### PR DESCRIPTION
First pass attempt to deduplicate and simplify descs (name, help, etc.).
There is a lot more I want to clean up, but I am not quite sure the best way to write some parts of this right now :thinking: 

**This also renames the metric `starlink_up` to `starlink_dish_up` for consistency.**