### PR TITLE
.goreleaser.yaml: fix docker image signing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -167,7 +167,8 @@ docker_manifests:
 
 # Sign Docker images and manifests.
 docker_signs:
-  - cmd: "cosign"
+  - artifacts: "all"
+    cmd: "cosign"
     args:
       - "sign"
       - "${artifact}"


### PR DESCRIPTION
Fix Docker image signing (cosign) in GoReleaser.
Per https://goreleaser.com/customization/docker_sign/, `artifacts` defaults to `none` - causing none of the Docker artifacts to be signed.