### PR TITLE
internal/exporter: add location metrics (fixes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,35 +12,39 @@ A simple Starlink exporter for Prometheus. *Not affiliated with Starlink or Spac
 
 The following metrics are exposed by this exporter:
 
-| Metric name                                        | Description                                                                   |
-|----------------------------------------------------|-------------------------------------------------------------------------------|
-| `starlink_dish_boresight_azimuth_deg`              | Starlink dish boresight azimuth degrees                                       |
-| `starlink_dish_boresight_elevation_deg`            | Starlink dish boresight elevation degrees                                     |
-| `starlink_dish_currently_obstructed`               | Whether the Starlink dish is currently obstructed                             |
-| `starlink_dish_desired_boresight_azimuth_deg`      | Starlink dish desired boresight azimuth degrees                               |
-| `starlink_dish_desired_boresight_elevation_deg`    | Starlink dish desired boresight elevation degrees                             |
-| `starlink_dish_downlink_throughput_bps_histogram`  | Histogram of Starlink dish downlink throughput over last 15 minutes           |
-| `starlink_dish_downlink_throughput_bps`            | Starlink dish downlink throughput in bit/sec                                  |
-| `starlink_dish_fraction_obstruction_ratio`         | Fraction of Starlink dish that is obstructed                                  |
-| `starlink_dish_gps_satellites`                     | Number of GPS satellites visible to the Starlink dish                         |
-| `starlink_dish_gps_valid`                          | Whether the Starlink dish GPS is valid                                        |
-| `starlink_dish_info`                               | Starlink dish software information                                            |
-| `starlink_dish_last_24h_obstructed_seconds`        | Number of seconds the Starlink dish was obstructed in the past 24 hours       |
-| `starlink_dish_pop_ping_drop_ratio`                | Starlink PoP ping drop ratio                                                  |
-| `starlink_dish_pop_ping_latency_seconds_histogram` | Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes   |
-| `starlink_dish_pop_ping_latency_seconds`           | Starlink PoP ping latency in seconds                                          |
-| `starlink_dish_power_input_watts_histogram`        | Histogram of Starlink dish power input in watts over last 15 minutes          |
-| `starlink_dish_power_input_watts`                  | Current power input for the Starlink dish                                     |
-| `starlink_dish_snr_above_noise_floor`              | Whether Starlink dish signal-to-noise ratio is above noise floor              |
-| `starlink_dish_snr_persistently_low`               | Whether Starlink dish signal-to-noise ratio is persistently low               |
-| `starlink_dish_software_update_reboot_ready`       | Whether the Starlink dish is ready to reboot to apply a software update       |
-| `starlink_dish_tilt_angle_deg`                     | Starlink dish tilt angle degrees                                              |
-| `starlink_dish_up`                                 | Whether scraping metrics from the Starlink dish was successful                |
-| `starlink_dish_uplink_throughput_bps_histogram`    | Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes |
-| `starlink_dish_uplink_throughput_bps`              | Starlink dish uplink throughput in bits/sec                                   |
-| `starlink_dish_uptime_seconds`                     | Starlink dish uptime in seconds                                               |
-| `starlink_exporter_scrape_duration_seconds`        | Time taken to scrape metrics from the Starlink dish                           |
-| `starlink_exporter_scrapes_total`                  | Total number of Starlink dish scrapes                                         |
+| Metric name                                        | Description                                                                                        |
+|----------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `starlink_dish_boresight_azimuth_deg`              | Starlink dish boresight azimuth degrees                                                            |
+| `starlink_dish_boresight_elevation_deg`            | Starlink dish boresight elevation degrees                                                          |
+| `starlink_dish_currently_obstructed`               | Whether the Starlink dish is currently obstructed                                                  |
+| `starlink_dish_desired_boresight_azimuth_deg`      | Starlink dish desired boresight azimuth degrees                                                    |
+| `starlink_dish_desired_boresight_elevation_deg`    | Starlink dish desired boresight elevation degrees                                                  |
+| `starlink_dish_downlink_throughput_bps_histogram`  | Histogram of Starlink dish downlink throughput over last 15 minutes                                |
+| `starlink_dish_downlink_throughput_bps`            | Starlink dish downlink throughput in bit/sec                                                       |
+| `starlink_dish_fraction_obstruction_ratio`         | Fraction of Starlink dish that is obstructed                                                       |
+| `starlink_dish_gps_satellites`                     | Number of GPS satellites visible to the Starlink dish                                              |
+| `starlink_dish_gps_valid`                          | Whether the Starlink dish GPS is valid                                                             |
+| `starlink_dish_info`                               | Starlink dish software information                                                                 |
+| `starlink_dish_last_24h_obstructed_seconds`        | Number of seconds the Starlink dish was obstructed in the past 24 hours                            |
+| `starlink_dish_location_altitude_meters`           | Location altitude in meters above sea level (requires location to be enabled in Starlink settings) |
+| `starlink_dish_location_info`                      | Dish location information (requires location to be enabled in Starlink settings)                   |
+| `starlink_dish_location_location_latitude_deg`     | Location latitude in degrees (requires location to be enabled in Starlink settings)                |
+| `starlink_dish_location_longitude_deg`             | Location longitude in degrees (requires location to be enabled in Starlink settings)               |
+| `starlink_dish_pop_ping_drop_ratio`                | Starlink PoP ping drop ratio                                                                       |
+| `starlink_dish_pop_ping_latency_seconds_histogram` | Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes                        |
+| `starlink_dish_pop_ping_latency_seconds`           | Starlink PoP ping latency in seconds                                                               |
+| `starlink_dish_power_input_watts_histogram`        | Histogram of Starlink dish power input in watts over last 15 minutes                               |
+| `starlink_dish_power_input_watts`                  | Current power input for the Starlink dish                                                          |
+| `starlink_dish_snr_above_noise_floor`              | Whether Starlink dish signal-to-noise ratio is above noise floor                                   |
+| `starlink_dish_snr_persistently_low`               | Whether Starlink dish signal-to-noise ratio is persistently low                                    |
+| `starlink_dish_software_update_reboot_ready`       | Whether the Starlink dish is ready to reboot to apply a software update                            |
+| `starlink_dish_tilt_angle_deg`                     | Starlink dish tilt angle degrees                                                                   |
+| `starlink_dish_up`                                 | Whether scraping metrics from the Starlink dish was successful                                     |
+| `starlink_dish_uplink_throughput_bps_histogram`    | Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes                      |
+| `starlink_dish_uplink_throughput_bps`              | Starlink dish uplink throughput in bits/sec                                                        |
+| `starlink_dish_uptime_seconds`                     | Starlink dish uptime in seconds                                                                    |
+| `starlink_exporter_scrape_duration_seconds`        | Time taken to scrape metrics from the Starlink dish                                                |
+| `starlink_exporter_scrapes_total`                  | Total number of Starlink dish scrapes                                                              |
 
 ## Installation
 

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Joshua Sing <joshua@joshuasing.dev>
+// Copyright (c) 2024-2025 Joshua Sing <joshua@joshuasing.dev>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -231,6 +231,26 @@ var (
 		Name:      "last_24h_obstructed_seconds",
 		Help:      "Number of seconds the Starlink dish was obstructed in the past 24 hours",
 	}
+
+	// Location
+	dishLocationLatitude = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "location_latitude",
+		Help:      "Location latitude in degrees",
+	}
+	dishLocationLongitude = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "location_longitude",
+		Help:      "Location longitude in degrees",
+	}
+	dishLocationAltitude = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "location_altitude",
+		Help:      "Location altitude in degrees",
+	}
 )
 
 var Descs = []Desc{
@@ -261,6 +281,9 @@ var Descs = []Desc{
 	dishLast24HoursObstructedSeconds,
 	dishPowerInputHistogram,
 	dishPowerInput,
+	dishLocationLatitude,
+	dishLocationLongitude,
+	dishLocationAltitude,
 }
 
 type Desc struct {

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -233,6 +233,13 @@ var (
 	}
 
 	// Location
+	dishLocationInfo = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "location_info",
+		Help:      "Dish location information",
+		Labels:    []string{"location_source", "lat", "lon", "alt"},
+	}
 	dishLocationLatitude = Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
@@ -281,6 +288,7 @@ var Descs = []Desc{
 	dishLast24HoursObstructedSeconds,
 	dishPowerInputHistogram,
 	dishPowerInput,
+	dishLocationInfo,
 	dishLocationLatitude,
 	dishLocationLongitude,
 	dishLocationAltitude,

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -243,20 +243,20 @@ var (
 	dishLocationLatitude = Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
-		Name:      "location_latitude",
+		Name:      "location_latitude_deg",
 		Help:      "Location latitude in degrees",
 	}
 	dishLocationLongitude = Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
-		Name:      "location_longitude",
+		Name:      "location_longitude_deg",
 		Help:      "Location longitude in degrees",
 	}
 	dishLocationAltitude = Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
-		Name:      "location_altitude",
-		Help:      "Location altitude in degrees",
+		Name:      "location_altitude_meters",
+		Help:      "Location altitude in meters above sea level",
 	}
 )
 

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -333,17 +333,17 @@ func (e *Exporter) scrapeLocation(ctx context.Context, ch chan<- prometheus.Metr
 		ftos(lla.GetAlt()),
 	)
 
-	// starlink_dish_location_latitude
+	// starlink_dish_location_latitude_deg
 	ch <- prometheus.MustNewConstMetric(
 		dishLocationLatitude.Desc(), prometheus.GaugeValue, lla.GetLat(),
 	)
 
-	// starlink_dish_location_longitude
+	// starlink_dish_location_longitude_deg
 	ch <- prometheus.MustNewConstMetric(
 		dishLocationLongitude.Desc(), prometheus.GaugeValue, lla.GetLon(),
 	)
 
-	// starlink_dish_location_altitude
+	// starlink_dish_location_altitude_meters
 	ch <- prometheus.MustNewConstMetric(
 		dishLocationAltitude.Desc(), prometheus.GaugeValue, lla.GetAlt(),
 	)

--- a/internal/exporter/util.go
+++ b/internal/exporter/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Joshua Sing <joshua@joshuasing.dev>
+// Copyright (c) 2024-2025 Joshua Sing <joshua@joshuasing.dev>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,11 +20,18 @@
 
 package exporter
 
-import "strconv"
+import (
+	"strconv"
+)
 
 // itos converts an int to a string.
 func itos[T int | int8 | int16 | int32 | int64](f T) string {
 	return strconv.FormatInt(int64(f), 10)
+}
+
+// ftos converts a float to a string.
+func ftos(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }
 
 // btof converts the bool to a float64 value of 1/0 (true/false).


### PR DESCRIPTION
Add optional location metrics, which requires location access to be enabled in Starlink settings.

Fixes #28