### PR TITLE
docker: add EXPOSE 9451 instruction (fix #32)

### DIFF
--- a/.goreleaser.Dockerfile
+++ b/.goreleaser.Dockerfile
@@ -58,4 +58,5 @@ COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY starlink_exporter /usr/local/bin/starlink_exporter
 
 USER starlink_exporter:starlink_exporter
+EXPOSE 9451/tcp
 ENTRYPOINT ["/usr/local/bin/starlink_exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,5 @@ COPY --from=build /etc/starlink_exporter /etc/starlink_exporter
 COPY --from=build /build/starlink_exporter/dist/starlink_exporter /usr/local/bin/starlink_exporter
 
 USER starlink_exporter:starlink_exporter
+EXPOSE 9451/tcp
 ENTRYPOINT ["/usr/local/bin/starlink_exporter"]


### PR DESCRIPTION
Add `EXPOSE 9451/tcp` to the Dockerfiles.

Fixes #32 