### PR TITLE
internal/exporter: expose Dish mobility class

### DIFF
--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -67,6 +67,7 @@ var (
 			"country_code",
 			"utc_offset",
 			"boot_count",
+			"mobility_class",
 		},
 	}
 	dishUptimeSeconds = Desc{
@@ -74,6 +75,12 @@ var (
 		Subsystem: dishSubsystem,
 		Name:      "uptime_seconds",
 		Help:      "Starlink dish uptime in seconds",
+	}
+	dishMobilityClass = Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "mobility_class",
+		Help:      "Starlink dish mobility class",
 	}
 
 	// Signal-to-noise ratio

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -130,12 +130,19 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 		deviceInfo.GetCountryCode(),
 		itos(deviceInfo.GetUtcOffsetS()),
 		itos(deviceInfo.GetBootcount()),
+		dishStatus.GetMobilityClass().String(),
 	)
 
 	// starlink_dish_uptime_seconds
 	ch <- prometheus.MustNewConstMetric(
 		dishUptimeSeconds.Desc(), prometheus.GaugeValue,
 		float64(deviceState.GetUptimeS()),
+	)
+
+	// starlink_dish_mobility_class
+	ch <- prometheus.MustNewConstMetric(
+		dishMobilityClass.Desc(), prometheus.GaugeValue,
+		float64(dishStatus.GetMobilityClass()),
 	)
 
 	// starlink_dish_pop_ping_latency_seconds


### PR DESCRIPTION
Expose Starlink dish mobility class as a label `mobility_class` in `starlink_dish_info` and as a separate metric `starlink_dish_mobility_class`.