### PR TITLE
internal/exporter: add five alert metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following metrics are exposed by this exporter:
 | `starlink_dish_alert_unexpected_location`          | Whether the Starlink dish is in an unexpected location                                             |
 | `starlink_dish_alert_install_pending`              | Whether a Starlink Dish software update is pending installation                                    |
 | `starlink_dish_alert_alert_is_heating`             | Whether the Starlink dish is heating (snow melting)                                                |
+| `starlink_dish_alert_is_power_save_idle`           | Whether the Starlink dish is currently in power saving mode                                        |
 | `starlink_dish_alert_signal_lower_than_predicted`  | Whether the Starlink dish signal is lower than predicted                                           |
 | `starlink_dish_boresight_azimuth_deg`              | Starlink dish boresight azimuth degrees                                                            |
 | `starlink_dish_boresight_elevation_deg`            | Starlink dish boresight elevation degrees                                                          |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The following metrics are exposed by this exporter:
 
 | Metric name                                        | Description                                                                                        |
 |----------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `starlink_dish_alert_unexpected_location`          | Whether the Starlink dish is in an unexpected location                                             |
+| `starlink_dish_alert_install_pending`              | Whether a Starlink Dish software update is pending installation                                    |
+| `starlink_dish_alert_alert_is_heating`             | Whether the Starlink dish is heating (snow melting)                                                |
+| `starlink_dish_alert_signal_lower_than_predicted`  | Whether the Starlink dish signal is lower than predicted                                           |
 | `starlink_dish_boresight_azimuth_deg`              | Starlink dish boresight azimuth degrees                                                            |
 | `starlink_dish_boresight_elevation_deg`            | Starlink dish boresight elevation degrees                                                          |
 | `starlink_dish_currently_obstructed`               | Whether the Starlink dish is currently obstructed                                                  |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,7 @@ Security patches will be provided **only** for the latest release of `starlink_e
 security updates are concentrated on the most up-to-date and stable version of the project. **Older versions will not
 receive security patches.**
 
-| Version   | Supported |
-|-----------|-----------|
-| `0.4.x`   | ✅         |
-| < `0.4.x` | ❌         |
+You can find the latest release of `starlink_exporter` at https://github.com/joshuasing/starlink_exporter/releases
 
 ## Reporting a Vulnerability
 

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -285,6 +285,12 @@ var (
 		Name:      "alert_is_heating",
 		Help:      "Whether the Starlink dish is heating (snow melting)",
 	}
+	dishAlertIsPowerSaveIdle = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_is_power_save_idle",
+		Help:      "Whether the Starlink dish is currently in power saving mode",
+	}
 	dishAlertSignalLowerThanPredicted = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
@@ -328,6 +334,7 @@ var Descs = []*Desc{
 	dishAlertUnexpectedLocation,
 	dishAlertInstallPending,
 	dishAlertIsHeating,
+	dishAlertIsPowerSaveIdle,
 	dishAlertSignalLowerThanPredicted,
 }
 

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -32,13 +32,13 @@ const (
 
 var (
 	// Exporter
-	exporterScrapesTotal = Desc{
+	exporterScrapesTotal = &Desc{
 		Namespace: namespace,
 		Subsystem: exporterSubsystem,
 		Name:      "scrapes_total",
 		Help:      "Total number of Starlink dish scrapes",
 	}
-	exporterScrapeDurationSeconds = Desc{
+	exporterScrapeDurationSeconds = &Desc{
 		Namespace: namespace,
 		Subsystem: exporterSubsystem,
 		Name:      "scrape_duration_seconds",
@@ -46,13 +46,13 @@ var (
 	}
 
 	// Informational
-	dishUp = Desc{
+	dishUp = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "up",
 		Help:      "Whether scraping metrics from the Starlink dish was successful",
 	}
-	dishInfo = Desc{
+	dishInfo = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "info",
@@ -70,13 +70,13 @@ var (
 			"mobility_class",
 		},
 	}
-	dishUptimeSeconds = Desc{
+	dishUptimeSeconds = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "uptime_seconds",
 		Help:      "Starlink dish uptime in seconds",
 	}
-	dishMobilityClass = Desc{
+	dishMobilityClass = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "mobility_class",
@@ -84,13 +84,13 @@ var (
 	}
 
 	// Signal-to-noise ratio
-	dishSnrAboveNoiseFloor = Desc{
+	dishSnrAboveNoiseFloor = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "snr_above_noise_floor",
 		Help:      "Whether Starlink dish signal-to-noise ratio is above noise floor",
 	}
-	dishSnrPersistentlyLow = Desc{
+	dishSnrPersistentlyLow = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "snr_persistently_low",
@@ -98,25 +98,25 @@ var (
 	}
 
 	// Throughput
-	dishUplinkThroughputBps = Desc{
+	dishUplinkThroughputBps = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "uplink_throughput_bps",
 		Help:      "Starlink dish uplink throughput in bits/sec",
 	}
-	dishDownlinkThroughputBps = Desc{
+	dishDownlinkThroughputBps = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "downlink_throughput_bps",
 		Help:      "Starlink dish downlink throughput in bit/sec",
 	}
-	dishDownlinkThroughputHistogram = Desc{
+	dishDownlinkThroughputHistogram = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "downlink_throughput_bps_histogram",
 		Help:      "Histogram of Starlink dish downlink throughput over last 15 minutes",
 	}
-	dishUplinkThroughputHistogram = Desc{
+	dishUplinkThroughputHistogram = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "uplink_throughput_bps_histogram",
@@ -124,19 +124,19 @@ var (
 	}
 
 	// PoP ping
-	dishPopPingDropRatio = Desc{
+	dishPopPingDropRatio = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "pop_ping_drop_ratio",
 		Help:      "Starlink PoP ping drop ratio",
 	}
-	dishPopPingLatencySeconds = Desc{
+	dishPopPingLatencySeconds = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "pop_ping_latency_seconds",
 		Help:      "Starlink PoP ping latency in seconds",
 	}
-	dishPopPingLatencyHistogram = Desc{
+	dishPopPingLatencyHistogram = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "pop_ping_latency_seconds_histogram",
@@ -144,13 +144,13 @@ var (
 	}
 
 	// Power In
-	dishPowerInputHistogram = Desc{
+	dishPowerInputHistogram = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "power_input_watts_histogram",
 		Help:      "Histogram of Starlink dish power input in watts over last 15 minutes",
 	}
-	dishPowerInput = Desc{
+	dishPowerInput = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "power_input_watts",
@@ -158,13 +158,13 @@ var (
 	}
 
 	// Software update
-	dishSoftwareUpdateState = Desc{
+	dishSoftwareUpdateState = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "software_update_state",
 		Help:      "Starlink dish update state",
 	}
-	dishSoftwareUpdateRebootReady = Desc{
+	dishSoftwareUpdateRebootReady = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "software_update_reboot_ready",
@@ -172,13 +172,13 @@ var (
 	}
 
 	// GPS
-	dishGPSValid = Desc{
+	dishGPSValid = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "gps_valid",
 		Help:      "Whether the Starlink dish GPS is valid",
 	}
-	dishGPSSatellites = Desc{
+	dishGPSSatellites = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "gps_satellites",
@@ -186,7 +186,7 @@ var (
 	}
 
 	// Tilt Angle
-	dishTiltAngleDeg = Desc{
+	dishTiltAngleDeg = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "tilt_angle_deg",
@@ -194,25 +194,25 @@ var (
 	}
 
 	// Boresight
-	dishBoresightAzimuthDeg = Desc{
+	dishBoresightAzimuthDeg = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "boresight_azimuth_deg",
 		Help:      "Starlink dish boresight azimuth degrees",
 	}
-	dishBoresightElevationDeg = Desc{
+	dishBoresightElevationDeg = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "boresight_elevation_deg",
 		Help:      "Starlink dish boresight elevation degrees",
 	}
-	dishDesiredBoresightAzimuthDeg = Desc{
+	dishDesiredBoresightAzimuthDeg = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "desired_boresight_azimuth_deg",
 		Help:      "Starlink dish desired boresight azimuth degrees",
 	}
-	dishDesiredBoresightElevationDeg = Desc{
+	dishDesiredBoresightElevationDeg = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "desired_boresight_elevation_deg",
@@ -220,19 +220,19 @@ var (
 	}
 
 	// Obstruction
-	dishCurrentlyObstructed = Desc{
+	dishCurrentlyObstructed = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "currently_obstructed",
 		Help:      "Whether the Starlink dish is currently obstructed",
 	}
-	dishFractionObstructionRatio = Desc{
+	dishFractionObstructionRatio = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "fraction_obstruction_ratio",
 		Help:      "Fraction of Starlink dish that is obstructed",
 	}
-	dishLast24HoursObstructedSeconds = Desc{
+	dishLast24HoursObstructedSeconds = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "last_24h_obstructed_seconds",
@@ -240,34 +240,60 @@ var (
 	}
 
 	// Location
-	dishLocationInfo = Desc{
+	dishLocationInfo = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "location_info",
 		Help:      "Dish location information",
 		Labels:    []string{"location_source", "lat", "lon", "alt"},
 	}
-	dishLocationLatitude = Desc{
+	dishLocationLatitude = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "location_latitude_deg",
 		Help:      "Location latitude in degrees",
 	}
-	dishLocationLongitude = Desc{
+	dishLocationLongitude = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "location_longitude_deg",
 		Help:      "Location longitude in degrees",
 	}
-	dishLocationAltitude = Desc{
+	dishLocationAltitude = &Desc{
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "location_altitude_meters",
 		Help:      "Location altitude in meters above sea level",
 	}
+
+	// Alerts
+	dishAlertUnexpectedLocation = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_unexpected_location",
+		Help:      "Whether the Starlink dish is in an unexpected location",
+	}
+	dishAlertInstallPending = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_install_pending",
+		Help:      "Whether a Starlink Dish software update is pending installation",
+	}
+	dishAlertIsHeating = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_is_heating",
+		Help:      "Whether the Starlink dish is heating",
+	}
+	dishAlertSignalLowerThanPredicted = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_signal_lower_than_predicted",
+		Help:      "Whether the Starlink dish signal is lower than predicted",
+	}
 )
 
-var Descs = []Desc{
+var Descs = []*Desc{
 	exporterScrapesTotal,
 	exporterScrapeDurationSeconds,
 	dishUp,
@@ -299,6 +325,10 @@ var Descs = []Desc{
 	dishLocationLatitude,
 	dishLocationLongitude,
 	dishLocationAltitude,
+	dishAlertUnexpectedLocation,
+	dishAlertInstallPending,
+	dishAlertIsHeating,
+	dishAlertSignalLowerThanPredicted,
 }
 
 type Desc struct {

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -283,7 +283,7 @@ var (
 		Namespace: namespace,
 		Subsystem: dishSubsystem,
 		Name:      "alert_is_heating",
-		Help:      "Whether the Starlink dish is heating",
+		Help:      "Whether the Starlink dish is heating (snow melting)",
 	}
 	dishAlertSignalLowerThanPredicted = &Desc{
 		Namespace: namespace,

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -117,10 +117,10 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 	deviceInfo := dishStatus.GetDeviceInfo()
 	deviceState := dishStatus.GetDeviceState()
 	obstructionStats := dishStatus.GetObstructionStats()
+	alerts := dishStatus.GetAlerts()
 
 	// starlink_dish_info
-	ch <- prometheus.MustNewConstMetric(
-		dishInfo.Desc(), prometheus.GaugeValue, 1,
+	ch <- metric(dishInfo, prometheus.GaugeValue, 1,
 		deviceInfo.GetId(),
 		deviceInfo.GetHardwareVersion(),
 		itos(deviceInfo.GetBoardRev()),
@@ -134,112 +134,92 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 	)
 
 	// starlink_dish_uptime_seconds
-	ch <- prometheus.MustNewConstMetric(
-		dishUptimeSeconds.Desc(), prometheus.GaugeValue,
-		float64(deviceState.GetUptimeS()),
-	)
+	ch <- metric(dishUptimeSeconds, prometheus.GaugeValue,
+		deviceState.GetUptimeS())
 
 	// starlink_dish_mobility_class
-	ch <- prometheus.MustNewConstMetric(
-		dishMobilityClass.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetMobilityClass()),
-	)
+	ch <- metric(dishMobilityClass, prometheus.GaugeValue,
+		dishStatus.GetMobilityClass())
 
 	// starlink_dish_pop_ping_latency_seconds
-	ch <- prometheus.MustNewConstMetric(
-		dishPopPingLatencySeconds.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetPopPingLatencyMs()/1000),
-	)
+	ch <- metric(dishPopPingLatencySeconds, prometheus.GaugeValue,
+		dishStatus.GetPopPingLatencyMs()/1000)
 
 	// starlink_dish_gps_valid
-	ch <- prometheus.MustNewConstMetric(
-		dishGPSValid.Desc(), prometheus.GaugeValue,
-		btof(dishStatus.GetGpsStats().GetGpsValid()),
-	)
+	ch <- metric(dishGPSValid, prometheus.GaugeValue,
+		btof(dishStatus.GetGpsStats().GetGpsValid()))
 
 	// starlink_dish_gps_satellites
-	ch <- prometheus.MustNewConstMetric(
-		dishGPSSatellites.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetGpsStats().GetGpsSats()),
-	)
+	ch <- metric(dishGPSSatellites, prometheus.GaugeValue,
+		dishStatus.GetGpsStats().GetGpsSats())
 
 	// starlink_dish_snr_above_noise_floor
-	ch <- prometheus.MustNewConstMetric(
-		dishSnrAboveNoiseFloor.Desc(), prometheus.GaugeValue,
-		btof(dishStatus.GetIsSnrAboveNoiseFloor()),
-	)
+	ch <- metric(dishSnrAboveNoiseFloor, prometheus.GaugeValue,
+		btof(dishStatus.GetIsSnrAboveNoiseFloor()))
 
 	// starlink_dish_snr_persistently_low
-	ch <- prometheus.MustNewConstMetric(
-		dishSnrPersistentlyLow.Desc(), prometheus.GaugeValue,
-		btof(dishStatus.GetIsSnrPersistentlyLow()),
-	)
+	ch <- metric(dishSnrPersistentlyLow, prometheus.GaugeValue,
+		btof(dishStatus.GetIsSnrPersistentlyLow()))
 
 	// starlink_dish_pop_ping_drop_ratio
-	ch <- prometheus.MustNewConstMetric(
-		dishPopPingDropRatio.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetPopPingDropRate()),
-	)
+	ch <- metric(dishPopPingDropRatio, prometheus.GaugeValue,
+		dishStatus.GetPopPingDropRate())
 
 	// starlink_dish_software_update_state
-	ch <- prometheus.MustNewConstMetric(
-		dishSoftwareUpdateState.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetSoftwareUpdateState()),
-	)
+	ch <- metric(dishSoftwareUpdateState, prometheus.GaugeValue,
+		dishStatus.GetSoftwareUpdateState())
 
 	// starlink_dish_software_update_reboot_ready
-	ch <- prometheus.MustNewConstMetric(
-		dishSoftwareUpdateRebootReady.Desc(), prometheus.GaugeValue,
-		btof(dishStatus.GetSwupdateRebootReady()),
-	)
+	ch <- metric(dishSoftwareUpdateRebootReady, prometheus.GaugeValue,
+		btof(dishStatus.GetSwupdateRebootReady()))
 
 	// starlink_dish_tilt_angle_deg
-	ch <- prometheus.MustNewConstMetric(
-		dishTiltAngleDeg.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetAlignmentStats().GetTiltAngleDeg()),
-	)
+	ch <- metric(dishTiltAngleDeg, prometheus.GaugeValue,
+		dishStatus.GetAlignmentStats().GetTiltAngleDeg())
 
 	// starlink_dish_boresight_azimuth_deg
-	ch <- prometheus.MustNewConstMetric(
-		dishBoresightAzimuthDeg.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetAlignmentStats().GetBoresightAzimuthDeg()),
-	)
+	ch <- metric(dishBoresightAzimuthDeg, prometheus.GaugeValue,
+		dishStatus.GetAlignmentStats().GetBoresightAzimuthDeg())
 
 	// starlink_dish_boresight_elevation_deg
-	ch <- prometheus.MustNewConstMetric(
-		dishBoresightElevationDeg.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetAlignmentStats().GetBoresightElevationDeg()),
-	)
+	ch <- metric(dishBoresightElevationDeg, prometheus.GaugeValue,
+		dishStatus.GetAlignmentStats().GetBoresightElevationDeg())
 
 	// starlink_dish_desired_boresight_azimuth_deg
-	ch <- prometheus.MustNewConstMetric(
-		dishDesiredBoresightAzimuthDeg.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetAlignmentStats().GetDesiredBoresightAzimuthDeg()),
-	)
+	ch <- metric(dishDesiredBoresightAzimuthDeg, prometheus.GaugeValue,
+		dishStatus.GetAlignmentStats().GetDesiredBoresightAzimuthDeg())
 
 	// starlink_dish_desired_boresight_elevation_deg
-	ch <- prometheus.MustNewConstMetric(
-		dishDesiredBoresightElevationDeg.Desc(), prometheus.GaugeValue,
-		float64(dishStatus.GetAlignmentStats().GetDesiredBoresightElevationDeg()),
-	)
+	ch <- metric(dishDesiredBoresightElevationDeg, prometheus.GaugeValue,
+		dishStatus.GetAlignmentStats().GetDesiredBoresightElevationDeg())
 
 	// starlink_dish_currently_obstructed
-	ch <- prometheus.MustNewConstMetric(
-		dishCurrentlyObstructed.Desc(), prometheus.GaugeValue,
-		btof(obstructionStats.GetCurrentlyObstructed()),
-	)
+	ch <- metric(dishCurrentlyObstructed, prometheus.GaugeValue,
+		btof(obstructionStats.GetCurrentlyObstructed()))
 
 	// starlink_dish_fraction_obstruction_ratio
-	ch <- prometheus.MustNewConstMetric(
-		dishFractionObstructionRatio.Desc(), prometheus.GaugeValue,
-		float64(obstructionStats.GetFractionObstructed()),
-	)
+	ch <- metric(dishFractionObstructionRatio, prometheus.GaugeValue,
+		obstructionStats.GetFractionObstructed())
 
 	// starlink_dish_last_24h_obstructed_seconds
-	ch <- prometheus.MustNewConstMetric(
-		dishLast24HoursObstructedSeconds.Desc(), prometheus.GaugeValue,
-		float64(obstructionStats.GetTimeObstructed()),
-	)
+	ch <- metric(dishLast24HoursObstructedSeconds, prometheus.GaugeValue,
+		obstructionStats.GetTimeObstructed())
+
+	// starlink_dish_alert_unexpected_location
+	ch <- metric(dishAlertUnexpectedLocation, prometheus.GaugeValue,
+		btof(alerts.GetUnexpectedLocation()))
+
+	// starlink_dish_alert_install_pending
+	ch <- metric(dishAlertInstallPending, prometheus.GaugeValue,
+		btof(alerts.GetInstallPending()))
+
+	// starlink_dish_alert_is_heating
+	ch <- metric(dishAlertIsHeating, prometheus.GaugeValue,
+		btof(alerts.GetIsHeating()))
+
+	// starlink_dish_alert_lower_than_predicted
+	ch <- metric(dishAlertSignalLowerThanPredicted, prometheus.GaugeValue,
+		btof(alerts.GetLowerSignalThanPredicted()))
 
 	return true
 }
@@ -273,10 +253,8 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 
 	// starlink_dish_downlink_throughput_bps
 	if len(downlinkData) > 0 {
-		ch <- prometheus.MustNewConstMetric(
-			dishDownlinkThroughputBps.Desc(), prometheus.GaugeValue,
-			float64(downlinkData[len(downlinkData)-1]),
-		)
+		ch <- metric(dishDownlinkThroughputBps, prometheus.GaugeValue,
+			downlinkData[len(downlinkData)-1])
 	}
 
 	// starlink_dish_uplink_throughput_bps_histogram
@@ -289,10 +267,8 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 
 	// starlink_dish_uplink_throughput_bps
 	if len(uplinkData) > 0 {
-		ch <- prometheus.MustNewConstMetric(
-			dishUplinkThroughputBps.Desc(), prometheus.GaugeValue,
-			float64(uplinkData[len(uplinkData)-1]),
-		)
+		ch <- metric(dishUplinkThroughputBps, prometheus.GaugeValue,
+			uplinkData[len(uplinkData)-1])
 	}
 
 	// starlink_dish_power_input_watts_histogram
@@ -305,10 +281,8 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 
 	// starlink_dish_power_input_watts
 	if len(powerData) > 0 {
-		ch <- prometheus.MustNewConstMetric(
-			dishPowerInput.Desc(), prometheus.GaugeValue,
-			float64(powerData[len(powerData)-1]),
-		)
+		ch <- metric(dishPowerInput, prometheus.GaugeValue,
+			powerData[len(powerData)-1])
 	}
 
 	return true
@@ -332,8 +306,7 @@ func (e *Exporter) scrapeLocation(ctx context.Context, ch chan<- prometheus.Metr
 	lla := loc.GetLla()
 
 	// starlink_dish_location_info
-	ch <- prometheus.MustNewConstMetric(
-		dishLocationInfo.Desc(), prometheus.GaugeValue, 1,
+	ch <- metric(dishLocationInfo, prometheus.GaugeValue, 1,
 		loc.GetSource().String(),
 		ftos(lla.GetLat()),
 		ftos(lla.GetLon()),
@@ -341,19 +314,13 @@ func (e *Exporter) scrapeLocation(ctx context.Context, ch chan<- prometheus.Metr
 	)
 
 	// starlink_dish_location_latitude_deg
-	ch <- prometheus.MustNewConstMetric(
-		dishLocationLatitude.Desc(), prometheus.GaugeValue, lla.GetLat(),
-	)
+	ch <- metric(dishLocationLatitude, prometheus.GaugeValue, lla.GetLat())
 
 	// starlink_dish_location_longitude_deg
-	ch <- prometheus.MustNewConstMetric(
-		dishLocationLongitude.Desc(), prometheus.GaugeValue, lla.GetLon(),
-	)
+	ch <- metric(dishLocationLongitude, prometheus.GaugeValue, lla.GetLon())
 
 	// starlink_dish_location_altitude_meters
-	ch <- prometheus.MustNewConstMetric(
-		dishLocationAltitude.Desc(), prometheus.GaugeValue, lla.GetAlt(),
-	)
+	ch <- metric(dishLocationAltitude, prometheus.GaugeValue, lla.GetAlt())
 
 	return true
 }

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -217,6 +217,10 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 	ch <- metric(dishAlertIsHeating, prometheus.GaugeValue,
 		btof(alerts.GetIsHeating()))
 
+	// starlink_dish_alert_is_power_save_idle
+	ch <- metric(dishAlertIsPowerSaveIdle, prometheus.GaugeValue,
+		btof(alerts.GetIsPowerSaveIdle()))
+
 	// starlink_dish_alert_lower_than_predicted
 	ch <- metric(dishAlertSignalLowerThanPredicted, prometheus.GaugeValue,
 		btof(alerts.GetLowerSignalThanPredicted()))

--- a/internal/exporter/util.go
+++ b/internal/exporter/util.go
@@ -22,7 +22,19 @@ package exporter
 
 import (
 	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+type numeric interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64
+}
+
+func metric[n numeric](desc *Desc, vt prometheus.ValueType, val n, labels ...string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(desc.Desc(), vt, float64(val), labels...)
+}
 
 // itos converts an int to a string.
 func itos[T int | int8 | int16 | int32 | int64](f T) string {


### PR DESCRIPTION
Add 5 new metrics from the Dish alerts:

| Metric name                                        | Description                                                                                        |
|----------------------------------------------------|----------------------------------------------------------------------------------------------------|
| `starlink_dish_alert_unexpected_location`          | Whether the Starlink dish is in an unexpected location                                             |
| `starlink_dish_alert_install_pending`              | Whether a Starlink Dish software update is pending installation                                    |
| `starlink_dish_alert_alert_is_heating`             | Whether the Starlink dish is heating (snow melting)                                                |
| `starlink_dish_alert_is_power_save_idle`           | Whether the Starlink dish is currently in power saving mode                                        |
| `starlink_dish_alert_signal_lower_than_predicted`  | Whether the Starlink dish signal is lower than predicted                                           |

This also adds a utility function `metric` which shortens `prometheus.MustNewConstMetric` calls.