### PR TITLE
cmd/starlink_exporter: fix pprof handlers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,12 @@ issues:
   # Exclude sources following the Go generated file convention.
   exclude-generated: "strict"
 
+  exclude-rules:
+    - path: 'cmd/starlink_exporter/main.go'
+      text: "G108:"
+      linters:
+        - gosec
+
 linters:
   enable:
     - "bodyclose"

--- a/cmd/starlink_exporter/main.go
+++ b/cmd/starlink_exporter/main.go
@@ -26,7 +26,7 @@ import (
 	"flag"
 	"log/slog"
 	"net/http"
-	"net/http/pprof"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"strings"
@@ -107,13 +107,6 @@ func run() int {
 		return 1
 	}
 	http.Handle("/", landingPage)
-
-	// pprof
-	http.HandleFunc("GET /debug/pprof/", pprof.Index)
-	http.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
-	http.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
-	http.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
-	http.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
 
 	// Run HTTP server in a goroutine
 	httpErr := make(chan error)


### PR DESCRIPTION
Fix pprof handler setup causing a panic at startup. This may have prevented the exporter from starting.
Sorry for the inconvenience.