### PR TITLE
all: build binaries for OpenBSD

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ builds:
       - "linux"
       - "windows"
       - "darwin"
+      - "openbsd"
     goarch:
       - "amd64"
       - "arm"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The following metrics are exposed by this exporter:
 
 ### Binaries
 
-Pre-built binaries are available from [GitHub Releases](https://github.com/joshuasing/starlink_exporter/releases).
+Pre-built binaries for Linux, macOS, Windows and OpenBSD are available
+from [GitHub Releases](https://github.com/joshuasing/starlink_exporter/releases).
 
 You can also use `go install` to build and install a binary from source:
 ```shell


### PR DESCRIPTION
Configure GoReleaser to build binaries for OpenBSD.