### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   GO_VERSION: "1.24.x"
-  GOLICENSER_VERSION: "0.1.0"
+  GOLICENSER_VERSION: "0.3.x"
 
 jobs:
   vulncheck:
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Setup Go ${{ env.GO_VERSION }}"
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: "Setup Go ${{ env.GO_VERSION }}"
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
@@ -81,14 +81,14 @@ jobs:
           fetch-depth: 0
 
       - name: "Setup Go ${{ env.GO_VERSION }}"
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
           check-latest: true
 
       - name: "Run golangci-lint"
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
 
       - name: "Cache golicenser"
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -120,7 +120,7 @@ jobs:
             SOFTWARE.
         run: |
           if ! (command -v 'golicenser' >/dev/null); then
-            go install github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION
+            go install "github.com/joshuasing/golicenser/cmd/golicenser@v$GOLICENSER_VERSION"
           fi
           echo "$LICENSE_HEADER" > license_header.txt
           golicenser -author="Joshua Sing <joshua@joshuasing.dev>" -year-mode=git-range ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     environment:
       name: "release"
     permissions:
-      contents: write
+      contents: write # Required to create releases.
       id-token: write
       packages: write
       attestations: write
@@ -32,23 +32,23 @@ jobs:
           fetch-depth: 0
 
       - name: "Setup Go ${{ env.GO_VERSION }}"
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           cache: true
           check-latest: true
 
       - name: "Install cosign"
-        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        uses: sigstore/cosign-installer@fb28c2b6339dcd94da6e4cbcbc5e888961f6f8c3 # v3.9.0
 
       - name: "Install Syft"
-        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+        uses: anchore/sbom-action/download-syft@9246b90769f852b3a8921f330c59e0b3f439d6e9 # v0.20.1
 
       - name: "Setup QEMU"
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: "Setup Docker Buildx"
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: "Login to DockerHub"
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -71,12 +71,6 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "Attest release artifacts"
-        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
-          subject-path: |
-            dist/**/starlink_exporter
-            dist/*.tar.gz
-            dist/*.zip
-            dist/*.txt
-            dist/*.pem
-            dist/*.sig
+          subject-checksums: ./dist/checksums.txt


### PR DESCRIPTION
Update used GitHub Actions to the latest versions.

This also updates the `attest-build-provenance` action to use `subject-checksums: ./dist/checksums.txt`, which will attest all build artifacts and is recommended by GoReleaser: https://goreleaser.com/customization/attestations/