### PR TITLE
ci: use containerd docker store for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,16 @@ jobs:
           cache: true
           check-latest: true
 
+      - name: "Setup Docker"
+        run: |
+          # Enable Docker containerd image store
+          if [ ! -s "/etc/docker/daemon.json" ]; then
+            echo '{}' | sudo tee /etc/docker/daemon.json
+          fi
+          cat /etc/docker/daemon.json | jq '. += {"features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker info -f '{{ .DriverStatus }}'
+
       - name: "Install cosign"
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,6 +98,7 @@ dockers:
       - "{{ .Env.DOCKER_HUB_USER }}/{{ .ProjectName }}:{{ .Version }}-amd64"
       - "ghcr.io/{{ .Env.GITHUB_USER }}/{{ .ProjectName }}:{{ .Version }}-amd64"
     build_flag_templates:
+      - "--pull"
       - "--platform=linux/amd64"
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
@@ -115,6 +116,7 @@ dockers:
       - "{{ .Env.DOCKER_HUB_USER }}/{{ .ProjectName }}:{{ .Version }}-arm64"
       - "ghcr.io/{{ .Env.GITHUB_USER }}/{{ .ProjectName }}:{{ .Version }}-arm64"
     build_flag_templates:
+      - "--pull"
       - "--platform=linux/arm64/v8"
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
@@ -133,6 +135,7 @@ dockers:
       - "{{ .Env.DOCKER_HUB_USER }}/{{ .ProjectName }}:{{ .Version }}-armv7"
       - "ghcr.io/{{ .Env.GITHUB_USER }}/{{ .ProjectName }}:{{ .Version }}-armv7"
     build_flag_templates:
+      - "--pull"
       - "--platform=linux/arm/v7"
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"


### PR DESCRIPTION
Adding attestations to cross-platform images requires using the containerd image store because GoReleaser uses the `--load` flag.