### PR TITLE
goreleaser: remove docker sboms, provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,16 +38,6 @@ jobs:
           cache: true
           check-latest: true
 
-      - name: "Setup Docker"
-        run: |
-          # Enable Docker containerd image store
-          if [ ! -s "/etc/docker/daemon.json" ]; then
-            echo '{}' | sudo tee /etc/docker/daemon.json
-          fi
-          cat /etc/docker/daemon.json | jq '. += {"features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-          docker info -f '{{ .DriverStatus }}'
-
       - name: "Install cosign"
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -103,8 +103,6 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
-      - "--sbom=true"
-      - "--provenance=mode=max"
 
   # linux/arm64/v8
   - id: "{{ .ProjectName }}-arm64"
@@ -121,8 +119,6 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
-      - "--sbom=true"
-      - "--provenance=mode=max"
 
   # linux/arm/v7
   - id: "{{ .ProjectName }}-armv7"
@@ -140,8 +136,6 @@ dockers:
       - "--build-arg=VERSION={{ .Version }}"
       - "--build-arg=VCS_REF={{ .FullCommit }}"
       - "--build-arg=BUILD_DATE={{ .Date }}"
-      - "--sbom=true"
-      - "--provenance=mode=max"
 
 # Create Docker manifests for each image, containing the images for each
 # supported system architecture.


### PR DESCRIPTION
With the current way GoReleaser is setup to build multi-platform images, using `--sbom` and `--provenance` results in an index per architecture, which fails when we create the Docker manifests later.

I'll figure out how to properly do this soon, but reverting for now.