### PR TITLE
ci: improve goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,9 @@ before:
 gomod:
   # Proxy the module from proxy.golang.org, making the builds verifiable.
   proxy: true
+  env:
+    - "GONOSUMCHECK="
+    - "GONOSUMDB="
 
 builds:
   - id: "starlink_exporter"
@@ -27,6 +30,7 @@ builds:
       -X github.com/prometheus/common/version.Branch={{ .Branch }}
       -X github.com/prometheus/common/version.BuildDate={{ .CommitDate }}
     flags: [ "-trimpath" ]
+    mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
       - "linux"
       - "windows"
@@ -42,16 +46,19 @@ builds:
         goarch: "arm"
 
 archives:
-  - formats: ["tar.gz"]
+  - formats: ["tar.gz", "tar.zst"]
     wrap_in_directory: true
     name_template: >-
       starlink_exporter_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: "windows"
         formats: ["zip"]
+    builds_info:
+      mtime: "{{ .CommitDate }}"
     files:
       - "README*"
       - "LICENSE*"
+      - "CHANGELOG*"
 
 # Create sources archive.
 source:
@@ -84,7 +91,7 @@ signs:
     output: true
 
 # Create Docker images:
-#  - starlink_exporter: linux/amd64, linux/arm64, linux/arm/v7
+#  - starlink_exporter: linux/amd64, linux/arm64
 dockers_v2:
   - id: "starlink_exporter"
     dockerfile: "docker/goreleaser.Dockerfile"
@@ -99,10 +106,20 @@ dockers_v2:
     platforms:
       - "linux/amd64"
       - "linux/arm64"
-    build_args:
-      VERSION: "{{ .Version }}"
-      VCS_REF: "{{ .FullCommit }}"
-      BUILD_DATE: "{{ .CommitDate }}"
+    labels:
+      "maintainer": "Joshua Sing <joshua@joshuasing.dev>"
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.authors": "Joshua Sing <joshua@joshuasing.dev>"
+      "org.opencontainers.image.url": "https://github.com/joshuasing/starlink_exporter"
+      "org.opencontainers.image.documentation": "https://github.com/joshuasing/starlink_exporter#readme"
+      "org.opencontainers.image.source": "https://github.com/joshuasing/starlink_exporter"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.licenses": "MIT"
+      "org.opencontainers.image.vendor": "Joshua Sing <joshua@joshuasing.dev>"
+      "org.opencontainers.image.title": "Starlink Prometheus Exporter"
+      "org.opencontainers.image.description": "Prometheus exporter for Starlink"
+      "org.opencontainers.image.base.name": "cgr.dev/chainguard/static"
 
 # Sign Docker images and manifests.
 docker_signs:
@@ -128,7 +145,65 @@ release:
     owner: "joshuasing"
     name: "starlink_exporter"
   draft: true
+  replace_existing_draft: true
   prerelease: auto
+  header: |
+    {{- if .Prerelease }}
+    > [!WARNING]
+    > This is a pre-release version ({{ .Prerelease }}) and may be unstable. Use in production is not recommended.
+    {{- end }}
+  footer: |
+    ---
+
+    - **Images:**
+      - `ghcr.io/joshuasing/starlink_exporter:{{ .Version }}`
+      - `docker.io/joshuasing/starlink_exporter:{{ .Version }}`
+    - **Build from source:**
+      - `go install github.com/joshuasing/starlink_exporter@v{{ .Version }}
+
+    All release artifacts are signed with [cosign](https://github.com/sigstore/cosign) and include SBOMs.
+
+    <details>
+    <summary>Image digests</summary>
+
+    ```
+    {{ readFile (printf "dist/starlink_exporter_v%s_image_digests.txt" .Version) -}}
+    ```
+    </details>
+
+    <details>
+    <summary>Verify release artifacts</summary>
+
+    First, download the checksums file and sigstore bundle, for example:
+    ```shell
+    curl --proto '=https' --tlsv1.3 -sSfLO https://github.com/joshuasing/starlink_exporter/releases/download/{{ .Tag }}/starlink_exporter_v{{ .Version }}_checksums.txt
+    curl --proto '=https' --tlsv1.3 -sSfLO https://github.com/joshuasing/starlink_exporter/releases/download/{{ .Tag }}/starlink_exporter_v{{ .Version }}_checksums.txt.sigstore.json
+    ```
+
+    Then, verify the checksums file using [`cosign`](https://github.com/sigstore/cosign):
+    ```shell
+    cosign verify-blob starlink_exporter_v{{ .Version }}_checksums.txt \
+      --bundle starlink_exporter_v{{ .Version }}_checksums.txt.sigstore.json \
+      --certificate-identity "https://github.com/joshuasing/starlink_exporter/.github/workflows/release.yml@refs/tags/{{ .Tag }}" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+    ```
+
+    If the output is `Verified OK`, you can safely verify the checksums of other artifacts, for example:
+    ```shell
+    shasum -a 256 --ignore-missing -c starlink_exporter_v{{ .Version }}_checksums.txt
+    ```
+
+    <details>
+    <summary>Verify OCI images</summary>
+
+    ```shell
+    cosign verify ghcr.io/joshuasing/starlink_exporter:{{ .Version }} \
+      --certificate-identity "https://github.com/joshuasing/starlink_exporter/.github/workflows/release.yml@refs/tags/{{ .Tag }}" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+    ```
+    </details>
+
+    **Full Changelog**: https://github.com/joshuasing/starlink_exporter/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 # Close milestones for the released tag.
 milestones:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support Starlink Dishy firmware `2026.03.15.mr76025.5` ([#185])
+- Support Starlink Dishy firmware `2026.04.07.mr77639.1` ([#201])
 
 ### Fixed
 
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added `tar.zst` release archives alongside `tar.gz` ([#202])
+- Improved build reproducibility with deterministic binary timestamps ([#202])
 - Updated to Go 1.26.1 ([#176], [#175])
 - Updated dependencies ([#168], [#177], [#182])
 
@@ -34,12 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated dependencies ([#136], [#138], [#139])
 
-### Contributors
-
-Thank you to everyone who contributed to this release!
-
-- [@joshuasing](https://github.com/joshuasing)
-
 ## [v0.7.3] - 2026-01-04
 
 ### Added
@@ -52,13 +48,7 @@ Thank you to everyone who contributed to this release!
 - Updated Go to 1.25.5 ([#123], [#124])
 - Updated dependencies ([#112], [#119], [#121], [#125], [#127], [#131])
 
-### Contributors
-
-Thank you to everyone who contributed to this release!
-
-- [@joshuasing](https://github.com/joshuasing)
-
-## [v0.7.1] -- 2025-10-27
+## [v0.7.1] - 2025-10-27
 
 ### Added
 
@@ -73,12 +63,6 @@ Thank you to everyone who contributed to this release!
 ### Removed
 
 - Removed support for `linux/arm/v7` in Docker images ([#105])
-
-### Contributors
-
-Thank you to everyone who contributed to this release!
-
-- [@joshuasing](https://github.com/joshuasing)
 
 -----
 
@@ -116,6 +100,7 @@ https://github.com/joshuasing/starlink_exporter/releases_
 [#176]: https://github.com/joshuasing/starlink_exporter/pull/176
 [#177]: https://github.com/joshuasing/starlink_exporter/pull/177
 [#182]: https://github.com/joshuasing/starlink_exporter/pull/182
-[#185]: https://github.com/joshuasing/starlink_exporter/pull/185
 [#186]: https://github.com/joshuasing/starlink_exporter/pull/186
 [#187]: https://github.com/joshuasing/starlink_exporter/pull/187
+[#201]: https://github.com/joshuasing/starlink_exporter/pull/201
+[#202]: https://github.com/joshuasing/starlink_exporter/pull/202

--- a/docker/goreleaser.Dockerfile
+++ b/docker/goreleaser.Dockerfile
@@ -20,23 +20,6 @@
 
 FROM cgr.dev/chainguard/static@sha256:d6d54da1c5bf5d9cecb231786adca86934607763067c8d7d9d22057abe6d5dbc
 
-# Build metadata
-ARG VERSION
-ARG VCS_REF
-ARG BUILD_DATE
-LABEL maintainer="Joshua Sing <joshua@joshuasing.dev>"
-LABEL org.opencontainers.image.created=$BUILD_DATE \
-      org.opencontainers.image.authors="Joshua Sing <joshua@joshuasing.dev>" \
-      org.opencontainers.image.url="https://github.com/joshuasing/starlink_exporter" \
-      org.opencontainers.image.source="https://github.com/joshuasing/starlink_exporter" \
-      org.opencontainers.image.version=$VERSION \
-      org.opencontainers.image.revision=$VCS_REF \
-      org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.vendor="Joshua Sing <joshua@joshuasing.dev>" \
-      org.opencontainers.image.title="Starlink Prometheus Exporter" \
-      org.opencontainers.image.description="A simple Starlink exporter for Prometheus"
-
-# Copy binary
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/starlink_exporter /usr/local/bin/starlink_exporter
 


### PR DESCRIPTION
Update GoReleaser config to:
1. Set `GONOSUMCHECK` and `GONOSUMDB` to empty, to ensure the sumdb is used.
2. Add `mod_timestamp` to builds to make binaries reproducible
3. Add `builds_info.mtime` to archives to make archives reproducible
4. Add `tar.zst` format to release archives
5. Include `CHANGELOG.md` file in release archives
6. Move GoReleaser Docker image labels to the `.gorelease.yaml` file instead of the Dockerfile.
7. Add header and footer to release notes.