### PR TITLE
ci: add ossf scorecard, improve security

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,8 @@ env:
   GOLANGCI_LINT_VERSION: "v2.11.4"
   # renovate: datasource=github-releases depName=joshuasing/golicenser versioning=semver
   GOLICENSER_VERSION: "v0.3.1"
+  # renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
+  GOVULNCHECK_VERSION: "v1.1.4"
 
 permissions:
   contents: read
@@ -27,6 +29,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -34,7 +38,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: "Install govulncheck"
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION
 
       - name: "Run govulncheck"
         run: govulncheck ./...
@@ -48,6 +52,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -71,6 +77,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         id: "go"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -43,6 +44,9 @@ jobs:
 
       - name: "Install Syft"
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          # renovate: datasource=github-releases depName=anchore/syft versioning=semver
+          syft-version: "v1.42.4"
 
       - name: "Setup QEMU"
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Joshua Sing <joshua@joshuasing.dev>
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+# GitHub Actions workflow to run OpenSSF Scorecard analysis.
+name: "Scorecard"
+on:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: "30 2 * * 1"
+
+jobs:
+  analysis:
+    name: "Scorecard Analysis"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run Scorecard"
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: "results.sarif"
+          results_format: "sarif"
+          publish_results: true
+
+      - name: "Upload results to code-scanning"
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: "results.sarif"
+
+      - name: "Upload results as artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "scorecard-results"
+          path: "results.sarif"
+          retention-days: 5

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/joshuasing/starlink_exporter.svg)](https://pkg.go.dev/github.com/joshuasing/starlink_exporter)
 [![Go Report Card](https://goreportcard.com/badge/github.com/joshuasing/starlink_exporter)](https://goreportcard.com/report/github.com/joshuasing/starlink_exporter)
 [![Go Build Status](https://github.com/joshuasing/starlink_exporter/actions/workflows/go.yml/badge.svg)](https://github.com/joshuasing/starlink_exporter/actions/workflows/go.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/joshuasing/starlink_exporter/badge)](https://scorecard.dev/viewer/?uri=github.com/joshuasing/starlink_exporter)
 [![Starlink Dishy Software Version](https://img.shields.io/badge/Starlink_Dishy_Version-2026.04.07.mr77639.1_(API_v42)-blue)](internal/spacex_api/README.md)
 [![MIT License](https://img.shields.io/badge/license-MIT-2155cc)](LICENSE)
 


### PR DESCRIPTION
- Pin govulncheck version in CI
- Pin syft version in CI
- Set `persist-credentials: false` for each `actions/checkout`
- Add OpenSSF scorecard workflow and badge