### PR TITLE
ci: fix formatting in draft release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: "ubuntu-latest"
     environment:
       name: "release"
+      deployment: false
     permissions:
       contents: write # Required to create GitHub releases.
       id-token: write # Required for Sigstore cosign authentication.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -159,7 +159,7 @@ release:
       - `ghcr.io/joshuasing/starlink_exporter:{{ .Version }}`
       - `docker.io/joshuasing/starlink_exporter:{{ .Version }}`
     - **Build from source:**
-      - `go install github.com/joshuasing/starlink_exporter@v{{ .Version }}
+      - `go install github.com/joshuasing/starlink_exporter@v{{ .Version }}`
 
     All release artifacts are signed with [cosign](https://github.com/sigstore/cosign) and include SBOMs.
 
@@ -167,7 +167,7 @@ release:
     <summary>Image digests</summary>
 
     ```
-    {{ readFile (printf "dist/starlink_exporter_v%s_image_digests.txt" .Version) -}}
+    {{ readFile (printf "dist/starlink_exporter_v%s_image_digests.txt" .Version) }}
     ```
     </details>
 
@@ -192,6 +192,7 @@ release:
     ```shell
     shasum -a 256 --ignore-missing -c starlink_exporter_v{{ .Version }}_checksums.txt
     ```
+    </details>
 
     <details>
     <summary>Verify OCI images</summary>


### PR DESCRIPTION
Fix a couple of formatting issues in the release footer in `.goreleaser.yaml`. Add `deployment: false` flag to release environment in release workflow.