### PR TITLE
Add additional metrics - Wifi and Dish

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,44 +13,194 @@ A simple Starlink exporter for Prometheus. *Not affiliated with Starlink or Spac
 
 The following metrics are exposed by this exporter:
 
-| Metric name                                        | Description                                                                   |
-|----------------------------------------------------|-------------------------------------------------------------------------------|
-| `starlink_exporter_scrapes_total`                  | Total number of Starlink dish scrapes                                         |
-| `starlink_exporter_scrape_duration_seconds`        | Time taken to scrape metrics from the Starlink dish                           |
-| `starlink_dish_up`                                 | Whether scraping metrics from the Starlink dish was successful                |
-| `starlink_dish_info`                               | Starlink dish software information                                            |
-| `starlink_dish_uptime_seconds`                     | Starlink dish uptime in seconds                                               |
-| `starlink_dish_snr_above_noise_floor`              | Whether Starlink dish signal-to-noise ratio is above noise floor              |
-| `starlink_dish_snr_persistently_low`               | Whether Starlink dish signal-to-noise ratio is persistently low               |
-| `starlink_dish_uplink_throughput_bps`              | Starlink dish uplink throughput in bits/sec                                   |
-| `starlink_dish_downlink_throughput_bps`            | Starlink dish downlink throughput in bit/sec                                  |
-| `starlink_dish_downlink_throughput_bps_histogram`  | Histogram of Starlink dish downlink throughput over last 15 minutes           |
-| `starlink_dish_uplink_throughput_bps_histogram`    | Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes |
-| `starlink_dish_pop_ping_drop_ratio`                | Starlink PoP ping drop ratio                                                  |
-| `starlink_dish_pop_ping_latency_seconds`           | Starlink PoP ping latency in seconds                                          |
-| `starlink_dish_pop_ping_latency_seconds_histogram` | Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes   |
-| `starlink_dish_software_update_reboot_ready`       | Whether the Starlink dish is ready to reboot to apply a software update       |
-| `starlink_dish_gps_valid`                          | Whether the Starlink dish GPS is valid                                        |
-| `starlink_dish_gps_satellites`                     | Number of GPS satellites visible to the Starlink dish                         |
-| `starlink_dish_tilt_angle_deg`                     | Starlink dish tilt angle degrees                                              |
-| `starlink_dish_boresight_azimuth_deg`              | Starlink dish boresight azimuth degrees                                       |
-| `starlink_dish_boresight_elevation_deg`            | Starlink dish boresight elevation degrees                                     |
-| `starlink_dish_desired_boresight_azimuth_deg`      | Starlink dish desired boresight azimuth degrees                               |
-| `starlink_dish_desired_boresight_elevation_deg`    | Starlink dish desired boresight elevation degrees                             |
-| `starlink_dish_currently_obstructed`               | Whether the Starlink dish is currently obstructed                             |
-| `starlink_dish_fraction_obstruction_ratio`         | Fraction of Starlink dish that is obstructed                                  |
-| `starlink_dish_last_24h_obstructed_seconds`        | Number of seconds the Starlink dish was obstructed in the past 24 hours       |
-| `starlink_dish_power_input_watts_histogram`        | Histogram of Starlink dish power input in watts over last 15 minutes          |
-| `starlink_dish_power_input_watts`                  | Current power input for the Starlink dish                                     |
-| `starlink_dish_location_info`                      | Dish location information                                                     |
-| `starlink_dish_location_latitude_deg`              | Location latitude in degrees                                                  |
-| `starlink_dish_location_longitude_deg`             | Location longitude in degrees                                                 |
-| `starlink_dish_location_altitude_meters`           | Location altitude in meters above sea level                                   |
-| `starlink_dish_alert_unexpected_location`          | Whether the Starlink dish is in an unexpected location                        |
-| `starlink_dish_alert_install_pending`              | Whether a Starlink Dish software update is pending installation               |
-| `starlink_dish_alert_is_heating`                   | Whether the Starlink dish is heating (snow melting)                           |
-| `starlink_dish_alert_is_power_save_idle`           | Whether the Starlink dish is currently in power saving mode                   |
-| `starlink_dish_alert_signal_lower_than_predicted`  | Whether the Starlink dish signal is lower than predicted                      |
+| Metric name                                                       | Description                                                                                 |
+|-------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `starlink_exporter_scrapes_total`                                 | Total number of Starlink dish scrapes                                                       |
+| `starlink_exporter_scrape_duration_seconds`                       | Time taken to scrape metrics from the Starlink dish                                         |
+| `starlink_dish_up`                                                | Whether scraping metrics from the Starlink dish was successful                              |
+| `starlink_dish_info`                                              | Starlink dish software information                                                          |
+| `starlink_dish_uptime_seconds`                                    | Starlink dish uptime in seconds                                                             |
+| `starlink_dish_mobility_class`                                    | Starlink dish mobility class                                                                |
+| `starlink_dish_snr_above_noise_floor`                             | Whether Starlink dish signal-to-noise ratio is above noise floor                            |
+| `starlink_dish_snr_persistently_low`                              | Whether Starlink dish signal-to-noise ratio is persistently low                             |
+| `starlink_dish_uplink_throughput_bps`                             | Starlink dish uplink throughput in bits/sec                                                 |
+| `starlink_dish_downlink_throughput_bps`                           | Starlink dish downlink throughput in bit/sec                                                |
+| `starlink_dish_downlink_throughput_bps_histogram`                 | Histogram of Starlink dish downlink throughput over last 15 minutes                         |
+| `starlink_dish_uplink_throughput_bps_histogram`                   | Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes               |
+| `starlink_dish_pop_ping_drop_ratio`                               | Starlink PoP ping drop ratio                                                                |
+| `starlink_dish_pop_ping_latency_seconds`                          | Starlink PoP ping latency in seconds                                                        |
+| `starlink_dish_pop_ping_latency_seconds_histogram`                | Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes                 |
+| `starlink_dish_software_update_state`                             | Starlink dish update state                                                                  |
+| `starlink_dish_software_update_reboot_ready`                      | Whether the Starlink dish is ready to reboot to apply a software update                     |
+| `starlink_dish_gps_valid`                                         | Whether the Starlink dish GPS is valid                                                      |
+| `starlink_dish_gps_satellites`                                    | Number of GPS satellites visible to the Starlink dish                                       |
+| `starlink_dish_tilt_angle_deg`                                    | Starlink dish tilt angle degrees                                                            |
+| `starlink_dish_boresight_azimuth_deg`                             | Starlink dish boresight azimuth degrees                                                     |
+| `starlink_dish_boresight_elevation_deg`                           | Starlink dish boresight elevation degrees                                                   |
+| `starlink_dish_desired_boresight_azimuth_deg`                     | Starlink dish desired boresight azimuth degrees                                             |
+| `starlink_dish_desired_boresight_elevation_deg`                   | Starlink dish desired boresight elevation degrees                                           |
+| `starlink_dish_currently_obstructed`                              | Whether the Starlink dish is currently obstructed                                           |
+| `starlink_dish_fraction_obstruction_ratio`                        | Fraction of Starlink dish that is obstructed                                                |
+| `starlink_dish_last_24h_obstructed_seconds`                       | Number of seconds the Starlink dish was obstructed in the past 24 hours                     |
+| `starlink_dish_power_input_watts_histogram`                       | Histogram of Starlink dish power input in watts over last 15 minutes                        |
+| `starlink_dish_power_input_watts`                                 | Current power input for the Starlink dish                                                   |
+| `starlink_dish_location_info`                                     | Dish location information                                                                   |
+| `starlink_dish_location_latitude_deg`                             | Location latitude in degrees                                                                |
+| `starlink_dish_location_longitude_deg`                            | Location longitude in degrees                                                               |
+| `starlink_dish_location_altitude_meters`                          | Location altitude in meters above sea level                                                 |
+| `starlink_dish_alert_unexpected_location`                         | Whether the Starlink dish is in an unexpected location                                      |
+| `starlink_dish_alert_install_pending`                             | Whether a Starlink Dish software update is pending installation                             |
+| `starlink_dish_alert_is_heating`                                  | Whether the Starlink dish is heating (snow melting)                                         |
+| `starlink_dish_alert_is_power_save_idle`                          | Whether the Starlink dish is currently in power saving mode                                 |
+| `starlink_dish_alert_signal_lower_than_predicted`                 | Whether the Starlink dish signal is lower than predicted                                    |
+| `starlink_dish_alert_motors_stuck`                                | Whether the Starlink dish motors are stuck                                                  |
+| `starlink_dish_alert_thermal_throttle`                            | Whether the Starlink dish is thermally throttled                                            |
+| `starlink_dish_alert_thermal_shutdown`                            | Whether the Starlink dish has thermally shut down                                           |
+| `starlink_dish_alert_mast_not_near_vertical`                      | Whether the Starlink dish mast is not near vertical                                         |
+| `starlink_dish_alert_slow_ethernet_speeds`                        | Whether the Starlink dish ethernet link is negotiated below gigabit                         |
+| `starlink_dish_alert_slow_ethernet_speeds_100`                    | Whether the Starlink dish ethernet link is negotiated at 100 Mbps or lower                  |
+| `starlink_dish_alert_roaming`                                     | Whether the Starlink dish is roaming                                                        |
+| `starlink_dish_alert_power_supply_thermal_throttle`               | Whether the Starlink dish power supply is thermally throttled                               |
+| `starlink_dish_alert_dbf_telem_stale`                             | Whether the Starlink dish DBF telemetry is stale                                            |
+| `starlink_dish_alert_low_motor_current`                           | Whether the Starlink dish has low motor current                                             |
+| `starlink_dish_alert_obstruction_map_reset`                       | Whether the Starlink dish obstruction map was reset                                         |
+| `starlink_dish_alert_dish_water_detected`                         | Whether water has been detected inside the Starlink dish                                    |
+| `starlink_dish_alert_router_water_detected`                       | Whether water has been detected inside the Starlink router                                  |
+| `starlink_dish_alert_upsu_router_port_slow`                       | Whether the Starlink dish UPSU router port is negotiated below the expected speed           |
+| `starlink_dish_alert_no_ethernet_link`                            | Whether the Starlink dish has no ethernet link                                              |
+| `starlink_dish_seconds_to_first_nonempty_slot`                    | Seconds until the next non-empty network schedule slot                                      |
+| `starlink_dish_stow_requested`                                    | Whether a stow has been requested for the Starlink dish                                     |
+| `starlink_dish_eth_speed_mbps`                                    | Negotiated speed of the Starlink dish ethernet link in Mbps                                 |
+| `starlink_dish_class_of_service`                                  | Starlink dish class of service                                                              |
+| `starlink_dish_reboot_reason`                                     | Reason for the most recent Starlink dish reboot                                             |
+| `starlink_dish_disablement_code`                                  | Reason the Starlink dish is disabled, if any                                                |
+| `starlink_dish_dl_bandwidth_restricted_reason`                    | Reason downlink bandwidth is currently restricted, if any                                   |
+| `starlink_dish_ul_bandwidth_restricted_reason`                    | Reason uplink bandwidth is currently restricted, if any                                     |
+| `starlink_dish_is_cell_disabled`                                  | Whether the Starlink dish cell is disabled                                                  |
+| `starlink_dish_seconds_until_swupdate_reboot_possible`            | Seconds until the Starlink dish can reboot to apply a software update                       |
+| `starlink_dish_high_power_test_mode`                              | Whether the Starlink dish is in high-power test mode                                        |
+| `starlink_dish_is_moving_fast_persisted`                          | Whether the Starlink dish has persistently detected fast movement                           |
+| `starlink_dish_mac_flag`                                          | Starlink dish MAC flag                                                                      |
+| `starlink_dish_nat_flag`                                          | Starlink dish NAT flag                                                                      |
+| `starlink_dish_account_shard`                                     | Starlink dish account shard                                                                 |
+| `starlink_dish_connected_routers_count`                           | Number of routers currently connected to the Starlink dish                                  |
+| `starlink_dish_has_actuators`                                     | Whether the Starlink dish has actuators                                                     |
+| `starlink_dish_ned2dish_quaternion_w`                             | W component of the NED-to-dish orientation quaternion                                       |
+| `starlink_dish_ned2dish_quaternion_x`                             | X component of the NED-to-dish orientation quaternion                                       |
+| `starlink_dish_ned2dish_quaternion_y`                             | Y component of the NED-to-dish orientation quaternion                                       |
+| `starlink_dish_ned2dish_quaternion_z`                             | Z component of the NED-to-dish orientation quaternion                                       |
+| `starlink_dish_outage_info`                                       | Information about the current Starlink dish outage, if any                                  |
+| `starlink_dish_outage_start_timestamp_seconds`                    | Unix timestamp at which the current outage started                                          |
+| `starlink_dish_outage_duration_seconds`                           | Duration of the current outage in seconds                                                   |
+| `starlink_dish_gps_no_sats_after_ttff`                            | Whether the Starlink dish has no GPS satellites after time-to-first-fix                     |
+| `starlink_dish_gps_inhibit`                                       | Whether GPS is currently inhibited on the Starlink dish                                     |
+| `starlink_dish_obstruction_valid_seconds`                         | Seconds the Starlink dish obstruction map has been collecting data                          |
+| `starlink_dish_obstruction_patches_valid`                         | Number of valid patches in the Starlink dish obstruction map                                |
+| `starlink_dish_avg_prolonged_obstruction_duration_seconds`        | Average duration of a prolonged obstruction in seconds                                      |
+| `starlink_dish_avg_prolonged_obstruction_interval_seconds`        | Average interval between prolonged obstructions in seconds                                  |
+| `starlink_dish_avg_prolonged_obstruction_valid`                   | Whether the average prolonged obstruction metrics are currently valid                       |
+| `starlink_dish_ready_state_cady`                                  | Whether the cady subsystem is ready                                                         |
+| `starlink_dish_ready_state_scp`                                   | Whether the SCP subsystem is ready                                                          |
+| `starlink_dish_ready_state_l1l2`                                  | Whether the L1/L2 subsystem is ready                                                        |
+| `starlink_dish_ready_state_xphy`                                  | Whether the XPHY subsystem is ready                                                         |
+| `starlink_dish_ready_state_aap`                                   | Whether the AAP subsystem is ready                                                          |
+| `starlink_dish_ready_state_rf`                                    | Whether the RF subsystem is ready                                                           |
+| `starlink_dish_software_update_progress`                          | Progress of the in-flight Starlink dish software update (0-1)                               |
+| `starlink_dish_software_update_requires_reboot`                   | Whether the pending Starlink dish software update requires a reboot                         |
+| `starlink_dish_software_update_reboot_scheduled_utc_seconds`      | Unix timestamp at which the Starlink dish is scheduled to reboot to apply a software update |
+| `starlink_dish_actuator_state`                                    | Current state of the Starlink dish actuators                                                |
+| `starlink_dish_attitude_estimation_state`                         | Current state of the Starlink dish attitude estimator                                       |
+| `starlink_dish_attitude_uncertainty_deg`                          | Starlink dish attitude uncertainty in degrees                                               |
+| `starlink_dish_initialization_attitude_seconds`                   | Seconds spent on attitude initialization during dish boot                                   |
+| `starlink_dish_initialization_burst_detected_seconds`             | Seconds until first burst was detected during dish boot                                     |
+| `starlink_dish_initialization_ekf_converged_seconds`              | Seconds until the EKF converged during dish boot                                            |
+| `starlink_dish_initialization_first_cplane_seconds`               | Seconds until first cplane message during dish boot                                         |
+| `starlink_dish_initialization_first_pop_ping_seconds`             | Seconds until first PoP ping during dish boot                                               |
+| `starlink_dish_initialization_gps_valid_seconds`                  | Seconds until GPS became valid during dish boot                                             |
+| `starlink_dish_initialization_initial_network_entry_seconds`      | Seconds until initial network entry during dish boot                                        |
+| `starlink_dish_initialization_network_schedule_seconds`           | Seconds until first network schedule was received during dish boot                          |
+| `starlink_dish_initialization_rf_ready_seconds`                   | Seconds until the RF subsystem was ready during dish boot                                   |
+| `starlink_dish_initialization_stable_connection_seconds`          | Seconds until a stable connection was established during dish boot                          |
+| `starlink_dish_plc_receiving`                                     | Whether the dish is receiving Power-Line Communication data                                 |
+| `starlink_dish_plc_average_time_to_empty_seconds`                 | Average time until the battery is empty in seconds                                          |
+| `starlink_dish_plc_average_time_to_full_seconds`                  | Average time until the battery is full in seconds                                           |
+| `starlink_dish_plc_battery_health`                                | Battery health as reported by PLC                                                           |
+| `starlink_dish_plc_permanent_failure`                             | Whether the PLC battery has reported a permanent failure                                    |
+| `starlink_dish_plc_safety_mode_active`                            | Whether the PLC battery is in safety mode                                                   |
+| `starlink_dish_plc_state_of_charge_percent`                       | PLC battery state of charge in percent                                                      |
+| `starlink_dish_plc_thermal_throttle_level`                        | PLC thermal throttle level                                                                  |
+| `starlink_dish_plc_revision`                                      | PLC protocol revision                                                                       |
+| `starlink_dish_upsu_dish_power_watts`                             | Dish power draw as reported by the UPSU in watts                                            |
+| `starlink_dish_upsu_router_power_watts`                           | Router power draw as reported by the UPSU in watts                                          |
+| `starlink_dish_upsu_uptime_seconds`                               | UPSU uptime in seconds                                                                      |
+| `starlink_dish_upsu_board_rev`                                    | UPSU board revision                                                                         |
+| `starlink_dish_aps_dish_power_watts`                              | Dish power draw as reported by the APS in watts                                             |
+| `starlink_dish_aps_uptime_seconds`                                | APS uptime in seconds                                                                       |
+| `starlink_dish_aps_board_rev`                                     | APS board revision                                                                          |
+| `starlink_dish_pop_ping_drop_ratio_histogram`                     | Histogram of Starlink dish PoP ping drop ratio over the last 15 minutes                     |
+| `starlink_dish_history_outages_count`                             | Number of outages retained in the Starlink dish history buffer                              |
+| `starlink_dish_location_uncertainty_meters`                       | 1-sigma uncertainty of the reported location in meters                                      |
+| `starlink_dish_horizontal_speed_mps`                              | Horizontal speed of the Starlink dish in meters per second                                  |
+| `starlink_dish_vertical_speed_mps`                                | Vertical speed of the Starlink dish in meters per second                                    |
+| `starlink_wifi_up`                                                | Whether scraping metrics from the Starlink WiFi router was successful                       |
+| `starlink_wifi_info`                                              | Starlink WiFi router software information                                                   |
+| `starlink_wifi_uptime_seconds`                                    | Starlink WiFi router uptime in seconds                                                      |
+| `starlink_wifi_hops_from_controller`                              | Number of mesh hops between this router and the controller                                  |
+| `starlink_wifi_no_wan_link`                                       | Whether the Starlink WiFi router has no WAN link                                            |
+| `starlink_wifi_is_aviation`                                       | Whether the Starlink WiFi router is in aviation mode                                        |
+| `starlink_wifi_is_aviation_conformed`                             | Whether the Starlink WiFi router is aviation conformed                                      |
+| `starlink_wifi_using_individualized_calibration`                  | Whether the Starlink WiFi router is using individualized calibration                        |
+| `starlink_wifi_calibration_partitions_state`                      | Starlink WiFi router calibration partitions state                                           |
+| `starlink_wifi_dish_disablement_code`                             | Disablement code reported by the dish as seen by the WiFi router                            |
+| `starlink_wifi_seconds_since_last_public_ipv4_change`             | Seconds since the public IPv4 address last changed                                          |
+| `starlink_wifi_clients_count`                                     | Number of clients currently connected to the Starlink WiFi router                           |
+| `starlink_wifi_dhcp_servers_count`                                | Number of DHCP servers reported by the Starlink WiFi router                                 |
+| `starlink_wifi_ping_drop_ratio`                                   | Router WAN ping drop ratio                                                                  |
+| `starlink_wifi_ping_drop_ratio_5m`                                | Router WAN ping drop ratio over the last 5 minutes                                          |
+| `starlink_wifi_ping_latency_seconds`                              | Router WAN ping latency in seconds                                                          |
+| `starlink_wifi_dish_ping_drop_ratio`                              | Router-to-dish ping drop ratio                                                              |
+| `starlink_wifi_dish_ping_drop_ratio_5m`                           | Router-to-dish ping drop ratio over the last 5 minutes                                      |
+| `starlink_wifi_dish_ping_latency_seconds`                         | Router-to-dish ping latency in seconds                                                      |
+| `starlink_wifi_pop_ping_drop_ratio`                               | Router-to-PoP ping drop ratio                                                               |
+| `starlink_wifi_pop_ping_drop_ratio_5m`                            | Router-to-PoP ping drop ratio over the last 5 minutes                                       |
+| `starlink_wifi_pop_ping_latency_seconds`                          | Router-to-PoP ping latency in seconds                                                       |
+| `starlink_wifi_pop_ipv6_ping_drop_ratio`                          | Router-to-PoP IPv6 ping drop ratio                                                          |
+| `starlink_wifi_pop_ipv6_ping_drop_ratio_5m`                       | Router-to-PoP IPv6 ping drop ratio over the last 5 minutes                                  |
+| `starlink_wifi_pop_ipv6_ping_latency_seconds`                     | Router-to-PoP IPv6 ping latency in seconds                                                  |
+| `starlink_wifi_alert_thermal_throttle`                            | Whether the Starlink WiFi router is thermally throttled                                     |
+| `starlink_wifi_alert_install_pending`                             | Whether a Starlink WiFi router software update is pending installation                      |
+| `starlink_wifi_alert_freshly_fused`                               | Whether the Starlink WiFi router was recently fused                                         |
+| `starlink_wifi_alert_lan_eth_slow_link_10`                        | Whether a Starlink WiFi router LAN ethernet link is negotiated at 10 Mbps                   |
+| `starlink_wifi_alert_lan_eth_slow_link_100`                       | Whether a Starlink WiFi router LAN ethernet link is negotiated at 100 Mbps                  |
+| `starlink_wifi_alert_high_cable_ping_drop_rate`                   | Whether the Starlink WiFi router is reporting a high cable ping drop rate                   |
+| `starlink_wifi_alert_wan_eth_poor_connection`                     | Whether the Starlink WiFi router WAN ethernet connection is poor                            |
+| `starlink_wifi_alert_mesh_topology_changing_often`                | Whether the Starlink WiFi mesh topology is changing often                                   |
+| `starlink_wifi_alert_mesh_unreliable_backhaul`                    | Whether the Starlink WiFi mesh backhaul is unreliable                                       |
+| `starlink_wifi_alert_radius_missing_process`                      | Whether the Starlink WiFi router RADIUS process is missing                                  |
+| `starlink_wifi_alert_eth_switch_error`                            | Whether the Starlink WiFi router ethernet switch has reported an error                      |
+| `starlink_wifi_alert_poe_on_dish_unreachable`                     | Whether the dish is unreachable while PoE is on                                             |
+| `starlink_wifi_alert_poe_fuse_blown`                              | Whether the Starlink WiFi router PoE fuse is blown                                          |
+| `starlink_wifi_alert_poe_router_overcurrent`                      | Whether the Starlink WiFi router PoE has detected an overcurrent                            |
+| `starlink_wifi_alert_poe_off_current_nominal`                     | Whether the Starlink WiFi router is drawing nominal current while PoE is off                |
+| `starlink_wifi_alert_poe_vin_overvoltage`                         | Whether the Starlink WiFi router PoE input voltage is over the threshold                    |
+| `starlink_wifi_alert_poe_vin_undervoltage`                        | Whether the Starlink WiFi router PoE input voltage is under the threshold                   |
+| `starlink_wifi_alert_sandbox_disabled`                            | Whether the Starlink WiFi router client sandbox is disabled                                 |
+| `starlink_wifi_alert_only_overflight_blocked`                     | Whether only overflight is blocked on the Starlink WiFi router                              |
+| `starlink_wifi_alert_offline_networks_disabled`                   | Whether offline networks are disabled on the Starlink WiFi router                           |
+| `starlink_wifi_alert_wired_mesh_not_using_wan_iface`              | Whether wired mesh is not using the WAN interface                                           |
+| `starlink_wifi_software_update_state`                             | Starlink WiFi router software update state                                                  |
+| `starlink_wifi_software_update_download_progress`                 | Progress of the in-flight Starlink WiFi router software update download (0-1)               |
+| `starlink_wifi_software_update_seconds_since_get_target_versions` | Seconds since the WiFi router last fetched its target software versions                     |
+| `starlink_wifi_software_update_info`                              | Starlink WiFi router software update version information                                    |
+| `starlink_wifi_poe_state`                                         | Starlink WiFi router PoE state                                                              |
+| `starlink_wifi_poe_power_watts`                                   | Starlink WiFi router PoE power draw in watts                                                |
+| `starlink_wifi_poe_faults_fast_overcurrent`                       | Number of fast overcurrent PoE faults reported by the WiFi router                           |
+| `starlink_wifi_poe_faults_slow_overcurrent`                       | Number of slow overcurrent PoE faults reported by the WiFi router                           |
+| `starlink_wifi_poe_faults_overvoltage`                            | Number of overvoltage PoE faults reported by the WiFi router                                |
+| `starlink_wifi_poe_faults_undervoltage`                           | Number of undervoltage PoE faults reported by the WiFi router                               |
+| `starlink_wifi_poe_vsns_vin_volts`                                | Starlink WiFi router PoE input voltage in volts                                             |
+| `starlink_wifi_setup_requirement_state`                           | Starlink WiFi router setup requirement state                                                |
+| `starlink_wifi_setup_requirement_pause_countdown_seconds`         | Seconds remaining before the WiFi router setup requirement pause expires                    |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ starlink_exporter --help
 #         Dish address (default "192.168.100.1:9200")
 #   -listen string
 #         Listen address (default ":9451")
+#   -router string
+#         WiFi router address (set empty to disable WiFi metrics) (default "192.168.1.1:9000")
 ```
 
 **Example**

--- a/cmd/starlink_exporter/main.go
+++ b/cmd/starlink_exporter/main.go
@@ -49,6 +49,8 @@ const defaultListenAddress = ":9451"
 var (
 	listenAddress = flag.String("listen", defaultListenAddress, "Listen address")
 	dishAddress   = flag.String("dish", exporter.DefaultDishAddress, "Dish address")
+	routerAddress = flag.String("router", exporter.DefaultRouterAddress,
+		"WiFi router address (set empty to disable WiFi metrics)")
 )
 
 func main() {
@@ -63,7 +65,7 @@ func run() int {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	ex, err := exporter.NewExporter(*dishAddress)
+	ex, err := exporter.NewExporter(*dishAddress, *routerAddress)
 	if err != nil {
 		slog.Error("Failed to create exporter", slog.Any("err", err))
 		return 1

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -298,6 +298,567 @@ var (
 		Name:      "alert_signal_lower_than_predicted",
 		Help:      "Whether the Starlink dish signal is lower than predicted",
 	}
+	dishAlertMotorsStuck = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_motors_stuck",
+		Help:      "Whether the Starlink dish motors are stuck",
+	}
+	dishAlertThermalThrottle = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_thermal_throttle",
+		Help:      "Whether the Starlink dish is thermally throttled",
+	}
+	dishAlertThermalShutdown = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_thermal_shutdown",
+		Help:      "Whether the Starlink dish has thermally shut down",
+	}
+	dishAlertMastNotNearVertical = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_mast_not_near_vertical",
+		Help:      "Whether the Starlink dish mast is not near vertical",
+	}
+	dishAlertSlowEthernetSpeeds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_slow_ethernet_speeds",
+		Help:      "Whether the Starlink dish ethernet link is negotiated below gigabit",
+	}
+	dishAlertSlowEthernetSpeeds100 = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_slow_ethernet_speeds_100",
+		Help:      "Whether the Starlink dish ethernet link is negotiated at 100 Mbps or lower",
+	}
+	dishAlertRoaming = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_roaming",
+		Help:      "Whether the Starlink dish is roaming",
+	}
+	dishAlertPowerSupplyThermalThrottle = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_power_supply_thermal_throttle",
+		Help:      "Whether the Starlink dish power supply is thermally throttled",
+	}
+	dishAlertDbfTelemStale = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_dbf_telem_stale",
+		Help:      "Whether the Starlink dish DBF telemetry is stale",
+	}
+	dishAlertLowMotorCurrent = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_low_motor_current",
+		Help:      "Whether the Starlink dish has low motor current",
+	}
+	dishAlertObstructionMapReset = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_obstruction_map_reset",
+		Help:      "Whether the Starlink dish obstruction map was reset",
+	}
+	dishAlertDishWaterDetected = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_dish_water_detected",
+		Help:      "Whether water has been detected inside the Starlink dish",
+	}
+	dishAlertRouterWaterDetected = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_router_water_detected",
+		Help:      "Whether water has been detected inside the Starlink router",
+	}
+	dishAlertUpsuRouterPortSlow = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_upsu_router_port_slow",
+		Help:      "Whether the Starlink dish UPSU router port is negotiated below the expected speed",
+	}
+	dishAlertNoEthernetLink = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_no_ethernet_link",
+		Help:      "Whether the Starlink dish has no ethernet link",
+	}
+
+	// Status (top-level scalars)
+	dishSecondsToFirstNonemptySlot = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "seconds_to_first_nonempty_slot",
+		Help:      "Seconds until the next non-empty network schedule slot",
+	}
+	dishStowRequested = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "stow_requested",
+		Help:      "Whether a stow has been requested for the Starlink dish",
+	}
+	dishEthSpeedMbps = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "eth_speed_mbps",
+		Help:      "Negotiated speed of the Starlink dish ethernet link in Mbps",
+	}
+	dishClassOfService = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "class_of_service",
+		Help:      "Starlink dish class of service",
+	}
+	dishRebootReason = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "reboot_reason",
+		Help:      "Reason for the most recent Starlink dish reboot",
+	}
+	dishDisablementCode = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "disablement_code",
+		Help:      "Reason the Starlink dish is disabled, if any",
+	}
+	dishDlBandwidthRestrictedReason = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "dl_bandwidth_restricted_reason",
+		Help:      "Reason downlink bandwidth is currently restricted, if any",
+	}
+	dishUlBandwidthRestrictedReason = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ul_bandwidth_restricted_reason",
+		Help:      "Reason uplink bandwidth is currently restricted, if any",
+	}
+	dishIsCellDisabled = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "is_cell_disabled",
+		Help:      "Whether the Starlink dish cell is disabled",
+	}
+	dishSecondsUntilSwupdateRebootPossible = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "seconds_until_swupdate_reboot_possible",
+		Help:      "Seconds until the Starlink dish can reboot to apply a software update",
+	}
+	dishHighPowerTestMode = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "high_power_test_mode",
+		Help:      "Whether the Starlink dish is in high-power test mode",
+	}
+	dishIsMovingFastPersisted = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "is_moving_fast_persisted",
+		Help:      "Whether the Starlink dish has persistently detected fast movement",
+	}
+	dishMacFlag = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "mac_flag",
+		Help:      "Starlink dish MAC flag",
+	}
+	dishNatFlag = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "nat_flag",
+		Help:      "Starlink dish NAT flag",
+	}
+	dishAccountShard = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "account_shard",
+		Help:      "Starlink dish account shard",
+	}
+	dishConnectedRoutersCount = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "connected_routers_count",
+		Help:      "Number of routers currently connected to the Starlink dish",
+	}
+	dishHasActuators = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "has_actuators",
+		Help:      "Whether the Starlink dish has actuators",
+	}
+	dishNed2DishQuaternionW = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ned2dish_quaternion_w",
+		Help:      "W component of the NED-to-dish orientation quaternion",
+	}
+	dishNed2DishQuaternionX = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ned2dish_quaternion_x",
+		Help:      "X component of the NED-to-dish orientation quaternion",
+	}
+	dishNed2DishQuaternionY = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ned2dish_quaternion_y",
+		Help:      "Y component of the NED-to-dish orientation quaternion",
+	}
+	dishNed2DishQuaternionZ = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ned2dish_quaternion_z",
+		Help:      "Z component of the NED-to-dish orientation quaternion",
+	}
+
+	// Current outage
+	dishOutageInfo = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "outage_info",
+		Help:      "Information about the current Starlink dish outage, if any",
+		Labels:    []string{"cause", "did_switch"},
+	}
+	dishOutageStartTimestampSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "outage_start_timestamp_seconds",
+		Help:      "Unix timestamp at which the current outage started",
+	}
+	dishOutageDurationSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "outage_duration_seconds",
+		Help:      "Duration of the current outage in seconds",
+	}
+
+	// GPS
+	dishGPSNoSatsAfterTtff = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "gps_no_sats_after_ttff",
+		Help:      "Whether the Starlink dish has no GPS satellites after time-to-first-fix",
+	}
+	dishGPSInhibit = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "gps_inhibit",
+		Help:      "Whether GPS is currently inhibited on the Starlink dish",
+	}
+
+	// Obstruction (additional)
+	dishObstructionValidSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "obstruction_valid_seconds",
+		Help:      "Seconds the Starlink dish obstruction map has been collecting data",
+	}
+	dishObstructionPatchesValid = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "obstruction_patches_valid",
+		Help:      "Number of valid patches in the Starlink dish obstruction map",
+	}
+	dishAvgProlongedObstructionDurationSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "avg_prolonged_obstruction_duration_seconds",
+		Help:      "Average duration of a prolonged obstruction in seconds",
+	}
+	dishAvgProlongedObstructionIntervalSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "avg_prolonged_obstruction_interval_seconds",
+		Help:      "Average interval between prolonged obstructions in seconds",
+	}
+	dishAvgProlongedObstructionValid = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "avg_prolonged_obstruction_valid",
+		Help:      "Whether the average prolonged obstruction metrics are currently valid",
+	}
+
+	// Ready states
+	dishReadyStateCady = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ready_state_cady",
+		Help:      "Whether the cady subsystem is ready",
+	}
+	dishReadyStateScp = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ready_state_scp",
+		Help:      "Whether the SCP subsystem is ready",
+	}
+	dishReadyStateL1L2 = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ready_state_l1l2",
+		Help:      "Whether the L1/L2 subsystem is ready",
+	}
+	dishReadyStateXphy = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ready_state_xphy",
+		Help:      "Whether the XPHY subsystem is ready",
+	}
+	dishReadyStateAap = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ready_state_aap",
+		Help:      "Whether the AAP subsystem is ready",
+	}
+	dishReadyStateRf = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "ready_state_rf",
+		Help:      "Whether the RF subsystem is ready",
+	}
+
+	// Software update (additional from SoftwareUpdateStats)
+	dishSoftwareUpdateProgress = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "software_update_progress",
+		Help:      "Progress of the in-flight Starlink dish software update (0-1)",
+	}
+	dishSoftwareUpdateRequiresReboot = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "software_update_requires_reboot",
+		Help:      "Whether the pending Starlink dish software update requires a reboot",
+	}
+	dishSoftwareUpdateRebootScheduledUtcSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "software_update_reboot_scheduled_utc_seconds",
+		Help:      "Unix timestamp at which the Starlink dish is scheduled to reboot to apply a software update",
+	}
+
+	// Alignment (additional)
+	dishActuatorState = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "actuator_state",
+		Help:      "Current state of the Starlink dish actuators",
+	}
+	dishAttitudeEstimationState = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "attitude_estimation_state",
+		Help:      "Current state of the Starlink dish attitude estimator",
+	}
+	dishAttitudeUncertaintyDeg = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "attitude_uncertainty_deg",
+		Help:      "Starlink dish attitude uncertainty in degrees",
+	}
+
+	// Initialization durations
+	dishInitAttitudeSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_attitude_seconds",
+		Help:      "Seconds spent on attitude initialization during dish boot",
+	}
+	dishInitBurstDetectedSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_burst_detected_seconds",
+		Help:      "Seconds until first burst was detected during dish boot",
+	}
+	dishInitEkfConvergedSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_ekf_converged_seconds",
+		Help:      "Seconds until the EKF converged during dish boot",
+	}
+	dishInitFirstCplaneSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_first_cplane_seconds",
+		Help:      "Seconds until first cplane message during dish boot",
+	}
+	dishInitFirstPopPingSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_first_pop_ping_seconds",
+		Help:      "Seconds until first PoP ping during dish boot",
+	}
+	dishInitGpsValidSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_gps_valid_seconds",
+		Help:      "Seconds until GPS became valid during dish boot",
+	}
+	dishInitInitialNetworkEntrySeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_initial_network_entry_seconds",
+		Help:      "Seconds until initial network entry during dish boot",
+	}
+	dishInitNetworkScheduleSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_network_schedule_seconds",
+		Help:      "Seconds until first network schedule was received during dish boot",
+	}
+	dishInitRfReadySeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_rf_ready_seconds",
+		Help:      "Seconds until the RF subsystem was ready during dish boot",
+	}
+	dishInitStableConnectionSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "initialization_stable_connection_seconds",
+		Help:      "Seconds until a stable connection was established during dish boot",
+	}
+
+	// PLC (Mini battery / Power-Line Communication)
+	dishPlcReceiving = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_receiving",
+		Help:      "Whether the dish is receiving Power-Line Communication data",
+	}
+	dishPlcAverageTimeToEmptySeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_average_time_to_empty_seconds",
+		Help:      "Average time until the battery is empty in seconds",
+	}
+	dishPlcAverageTimeToFullSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_average_time_to_full_seconds",
+		Help:      "Average time until the battery is full in seconds",
+	}
+	dishPlcBatteryHealth = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_battery_health",
+		Help:      "Battery health as reported by PLC",
+	}
+	dishPlcPermanentFailure = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_permanent_failure",
+		Help:      "Whether the PLC battery has reported a permanent failure",
+	}
+	dishPlcSafetyModeActive = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_safety_mode_active",
+		Help:      "Whether the PLC battery is in safety mode",
+	}
+	dishPlcStateOfChargePercent = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_state_of_charge_percent",
+		Help:      "PLC battery state of charge in percent",
+	}
+	dishPlcThermalThrottleLevel = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_thermal_throttle_level",
+		Help:      "PLC thermal throttle level",
+	}
+	dishPlcRevision = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "plc_revision",
+		Help:      "PLC protocol revision",
+	}
+
+	// UPSU (Universal Power Supply Unit, Gen 3)
+	dishUpsuDishPowerWatts = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "upsu_dish_power_watts",
+		Help:      "Dish power draw as reported by the UPSU in watts",
+	}
+	dishUpsuRouterPowerWatts = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "upsu_router_power_watts",
+		Help:      "Router power draw as reported by the UPSU in watts",
+	}
+	dishUpsuUptimeSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "upsu_uptime_seconds",
+		Help:      "UPSU uptime in seconds",
+	}
+	dishUpsuBoardRev = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "upsu_board_rev",
+		Help:      "UPSU board revision",
+	}
+
+	// APS (Auxiliary Power Supply)
+	dishApsDishPowerWatts = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "aps_dish_power_watts",
+		Help:      "Dish power draw as reported by the APS in watts",
+	}
+	dishApsUptimeSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "aps_uptime_seconds",
+		Help:      "APS uptime in seconds",
+	}
+	dishApsBoardRev = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "aps_board_rev",
+		Help:      "APS board revision",
+	}
+
+	// History (additional)
+	dishPopPingDropRatioHistogram = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "pop_ping_drop_ratio_histogram",
+		Help:      "Histogram of Starlink dish PoP ping drop ratio over the last 15 minutes",
+	}
+	dishHistoryOutagesCount = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "history_outages_count",
+		Help:      "Number of outages retained in the Starlink dish history buffer",
+	}
+
+	// Location (additional)
+	dishLocationUncertaintyMeters = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "location_uncertainty_meters",
+		Help:      "1-sigma uncertainty of the reported location in meters",
+	}
+	dishHorizontalSpeedMps = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "horizontal_speed_mps",
+		Help:      "Horizontal speed of the Starlink dish in meters per second",
+	}
+	dishVerticalSpeedMps = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "vertical_speed_mps",
+		Help:      "Vertical speed of the Starlink dish in meters per second",
+	}
 )
 
 // Descs contains all Prometheus metrics descriptors for the exporter.
@@ -340,6 +901,95 @@ var Descs = []*Desc{
 	dishAlertIsHeating,
 	dishAlertIsPowerSaveIdle,
 	dishAlertSignalLowerThanPredicted,
+	dishAlertMotorsStuck,
+	dishAlertThermalThrottle,
+	dishAlertThermalShutdown,
+	dishAlertMastNotNearVertical,
+	dishAlertSlowEthernetSpeeds,
+	dishAlertSlowEthernetSpeeds100,
+	dishAlertRoaming,
+	dishAlertPowerSupplyThermalThrottle,
+	dishAlertDbfTelemStale,
+	dishAlertLowMotorCurrent,
+	dishAlertObstructionMapReset,
+	dishAlertDishWaterDetected,
+	dishAlertRouterWaterDetected,
+	dishAlertUpsuRouterPortSlow,
+	dishAlertNoEthernetLink,
+	dishSecondsToFirstNonemptySlot,
+	dishStowRequested,
+	dishEthSpeedMbps,
+	dishClassOfService,
+	dishRebootReason,
+	dishDisablementCode,
+	dishDlBandwidthRestrictedReason,
+	dishUlBandwidthRestrictedReason,
+	dishIsCellDisabled,
+	dishSecondsUntilSwupdateRebootPossible,
+	dishHighPowerTestMode,
+	dishIsMovingFastPersisted,
+	dishMacFlag,
+	dishNatFlag,
+	dishAccountShard,
+	dishConnectedRoutersCount,
+	dishHasActuators,
+	dishNed2DishQuaternionW,
+	dishNed2DishQuaternionX,
+	dishNed2DishQuaternionY,
+	dishNed2DishQuaternionZ,
+	dishOutageInfo,
+	dishOutageStartTimestampSeconds,
+	dishOutageDurationSeconds,
+	dishGPSNoSatsAfterTtff,
+	dishGPSInhibit,
+	dishObstructionValidSeconds,
+	dishObstructionPatchesValid,
+	dishAvgProlongedObstructionDurationSeconds,
+	dishAvgProlongedObstructionIntervalSeconds,
+	dishAvgProlongedObstructionValid,
+	dishReadyStateCady,
+	dishReadyStateScp,
+	dishReadyStateL1L2,
+	dishReadyStateXphy,
+	dishReadyStateAap,
+	dishReadyStateRf,
+	dishSoftwareUpdateProgress,
+	dishSoftwareUpdateRequiresReboot,
+	dishSoftwareUpdateRebootScheduledUtcSeconds,
+	dishActuatorState,
+	dishAttitudeEstimationState,
+	dishAttitudeUncertaintyDeg,
+	dishInitAttitudeSeconds,
+	dishInitBurstDetectedSeconds,
+	dishInitEkfConvergedSeconds,
+	dishInitFirstCplaneSeconds,
+	dishInitFirstPopPingSeconds,
+	dishInitGpsValidSeconds,
+	dishInitInitialNetworkEntrySeconds,
+	dishInitNetworkScheduleSeconds,
+	dishInitRfReadySeconds,
+	dishInitStableConnectionSeconds,
+	dishPlcReceiving,
+	dishPlcAverageTimeToEmptySeconds,
+	dishPlcAverageTimeToFullSeconds,
+	dishPlcBatteryHealth,
+	dishPlcPermanentFailure,
+	dishPlcSafetyModeActive,
+	dishPlcStateOfChargePercent,
+	dishPlcThermalThrottleLevel,
+	dishPlcRevision,
+	dishUpsuDishPowerWatts,
+	dishUpsuRouterPowerWatts,
+	dishUpsuUptimeSeconds,
+	dishUpsuBoardRev,
+	dishApsDishPowerWatts,
+	dishApsUptimeSeconds,
+	dishApsBoardRev,
+	dishPopPingDropRatioHistogram,
+	dishHistoryOutagesCount,
+	dishLocationUncertaintyMeters,
+	dishHorizontalSpeedMps,
+	dishVerticalSpeedMps,
 }
 
 // Desc is a utility wrapper for prometheus.Desc.

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -28,6 +28,7 @@ import (
 const (
 	namespace         = "starlink"
 	dishSubsystem     = "dish"
+	wifiSubsystem     = "wifi"
 	exporterSubsystem = "exporter"
 )
 
@@ -859,6 +860,386 @@ var (
 		Name:      "vertical_speed_mps",
 		Help:      "Vertical speed of the Starlink dish in meters per second",
 	}
+
+	// WiFi router
+
+	// Informational
+	wifiUp = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "up",
+		Help:      "Whether scraping metrics from the Starlink WiFi router was successful",
+	}
+	wifiInfo = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "info",
+		Help:      "Starlink WiFi router software information",
+		Labels: []string{
+			"device_id",
+			"hardware_version",
+			"board_rev",
+			"software_version",
+			"manufactured_version",
+			"generation_number",
+			"country_code",
+			"utc_offset",
+			"boot_count",
+		},
+	}
+	wifiUptimeSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "uptime_seconds",
+		Help:      "Starlink WiFi router uptime in seconds",
+	}
+	wifiHopsFromController = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "hops_from_controller",
+		Help:      "Number of mesh hops between this router and the controller",
+	}
+	wifiNoWanLink = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "no_wan_link",
+		Help:      "Whether the Starlink WiFi router has no WAN link",
+	}
+	wifiIsAviation = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "is_aviation",
+		Help:      "Whether the Starlink WiFi router is in aviation mode",
+	}
+	wifiIsAviationConformed = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "is_aviation_conformed",
+		Help:      "Whether the Starlink WiFi router is aviation conformed",
+	}
+	wifiUsingIndividualizedCalibration = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "using_individualized_calibration",
+		Help:      "Whether the Starlink WiFi router is using individualized calibration",
+	}
+	wifiCalibrationPartitionsState = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "calibration_partitions_state",
+		Help:      "Starlink WiFi router calibration partitions state",
+	}
+	wifiDishDisablementCode = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "dish_disablement_code",
+		Help:      "Disablement code reported by the dish as seen by the WiFi router",
+	}
+	wifiSecsSinceLastPublicIpv4Change = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "seconds_since_last_public_ipv4_change",
+		Help:      "Seconds since the public IPv4 address last changed",
+	}
+	wifiClientsCount = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "clients_count",
+		Help:      "Number of clients currently connected to the Starlink WiFi router",
+	}
+	wifiDhcpServersCount = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "dhcp_servers_count",
+		Help:      "Number of DHCP servers reported by the Starlink WiFi router",
+	}
+
+	// Ping
+	wifiPingDropRatio = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "ping_drop_ratio",
+		Help:      "Router WAN ping drop ratio",
+	}
+	wifiPingDropRatio5m = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "ping_drop_ratio_5m",
+		Help:      "Router WAN ping drop ratio over the last 5 minutes",
+	}
+	wifiPingLatencySeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "ping_latency_seconds",
+		Help:      "Router WAN ping latency in seconds",
+	}
+	wifiDishPingDropRatio = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "dish_ping_drop_ratio",
+		Help:      "Router-to-dish ping drop ratio",
+	}
+	wifiDishPingDropRatio5m = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "dish_ping_drop_ratio_5m",
+		Help:      "Router-to-dish ping drop ratio over the last 5 minutes",
+	}
+	wifiDishPingLatencySeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "dish_ping_latency_seconds",
+		Help:      "Router-to-dish ping latency in seconds",
+	}
+	wifiPopPingDropRatio = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "pop_ping_drop_ratio",
+		Help:      "Router-to-PoP ping drop ratio",
+	}
+	wifiPopPingDropRatio5m = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "pop_ping_drop_ratio_5m",
+		Help:      "Router-to-PoP ping drop ratio over the last 5 minutes",
+	}
+	wifiPopPingLatencySeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "pop_ping_latency_seconds",
+		Help:      "Router-to-PoP ping latency in seconds",
+	}
+	wifiPopIpv6PingDropRatio = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "pop_ipv6_ping_drop_ratio",
+		Help:      "Router-to-PoP IPv6 ping drop ratio",
+	}
+	wifiPopIpv6PingDropRatio5m = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "pop_ipv6_ping_drop_ratio_5m",
+		Help:      "Router-to-PoP IPv6 ping drop ratio over the last 5 minutes",
+	}
+	wifiPopIpv6PingLatencySeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "pop_ipv6_ping_latency_seconds",
+		Help:      "Router-to-PoP IPv6 ping latency in seconds",
+	}
+
+	// Alerts
+	wifiAlertThermalThrottle = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_thermal_throttle",
+		Help:      "Whether the Starlink WiFi router is thermally throttled",
+	}
+	wifiAlertInstallPending = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_install_pending",
+		Help:      "Whether a Starlink WiFi router software update is pending installation",
+	}
+	wifiAlertFreshlyFused = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_freshly_fused",
+		Help:      "Whether the Starlink WiFi router was recently fused",
+	}
+	wifiAlertLanEthSlowLink10 = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_lan_eth_slow_link_10",
+		Help:      "Whether a Starlink WiFi router LAN ethernet link is negotiated at 10 Mbps",
+	}
+	wifiAlertLanEthSlowLink100 = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_lan_eth_slow_link_100",
+		Help:      "Whether a Starlink WiFi router LAN ethernet link is negotiated at 100 Mbps",
+	}
+	wifiAlertHighCablePingDropRate = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_high_cable_ping_drop_rate",
+		Help:      "Whether the Starlink WiFi router is reporting a high cable ping drop rate",
+	}
+	wifiAlertWanEthPoorConnection = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_wan_eth_poor_connection",
+		Help:      "Whether the Starlink WiFi router WAN ethernet connection is poor",
+	}
+	wifiAlertMeshTopologyChangingOften = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_mesh_topology_changing_often",
+		Help:      "Whether the Starlink WiFi mesh topology is changing often",
+	}
+	wifiAlertMeshUnreliableBackhaul = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_mesh_unreliable_backhaul",
+		Help:      "Whether the Starlink WiFi mesh backhaul is unreliable",
+	}
+	wifiAlertRadiusMissingProcess = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_radius_missing_process",
+		Help:      "Whether the Starlink WiFi router RADIUS process is missing",
+	}
+	wifiAlertEthSwitchError = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_eth_switch_error",
+		Help:      "Whether the Starlink WiFi router ethernet switch has reported an error",
+	}
+	wifiAlertPoeOnDishUnreachable = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_poe_on_dish_unreachable",
+		Help:      "Whether the dish is unreachable while PoE is on",
+	}
+	wifiAlertPoeFuseBlown = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_poe_fuse_blown",
+		Help:      "Whether the Starlink WiFi router PoE fuse is blown",
+	}
+	wifiAlertPoeRouterOvercurrent = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_poe_router_overcurrent",
+		Help:      "Whether the Starlink WiFi router PoE has detected an overcurrent",
+	}
+	wifiAlertPoeOffCurrentNominal = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_poe_off_current_nominal",
+		Help:      "Whether the Starlink WiFi router is drawing nominal current while PoE is off",
+	}
+	wifiAlertPoeVinOvervoltage = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_poe_vin_overvoltage",
+		Help:      "Whether the Starlink WiFi router PoE input voltage is over the threshold",
+	}
+	wifiAlertPoeVinUndervoltage = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_poe_vin_undervoltage",
+		Help:      "Whether the Starlink WiFi router PoE input voltage is under the threshold",
+	}
+	wifiAlertSandboxDisabled = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_sandbox_disabled",
+		Help:      "Whether the Starlink WiFi router client sandbox is disabled",
+	}
+	wifiAlertOnlyOverflightBlocked = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_only_overflight_blocked",
+		Help:      "Whether only overflight is blocked on the Starlink WiFi router",
+	}
+	wifiAlertOfflineNetworksDisabled = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_offline_networks_disabled",
+		Help:      "Whether offline networks are disabled on the Starlink WiFi router",
+	}
+	wifiAlertWiredMeshNotUsingWanIface = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "alert_wired_mesh_not_using_wan_iface",
+		Help:      "Whether wired mesh is not using the WAN interface",
+	}
+
+	// Software update
+	wifiSoftwareUpdateState = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "software_update_state",
+		Help:      "Starlink WiFi router software update state",
+	}
+	wifiSoftwareUpdateDownloadProgress = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "software_update_download_progress",
+		Help:      "Progress of the in-flight Starlink WiFi router software update download (0-1)",
+	}
+	wifiSoftwareUpdateSecondsSinceGetTargetVersions = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "software_update_seconds_since_get_target_versions",
+		Help:      "Seconds since the WiFi router last fetched its target software versions",
+	}
+	wifiSoftwareUpdateInfo = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "software_update_info",
+		Help:      "Starlink WiFi router software update version information",
+		Labels:    []string{"running_version", "version_in_progress"},
+	}
+
+	// PoE
+	wifiPoeState = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "poe_state",
+		Help:      "Starlink WiFi router PoE state",
+	}
+	wifiPoePowerWatts = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "poe_power_watts",
+		Help:      "Starlink WiFi router PoE power draw in watts",
+	}
+	wifiPoeFaultsFastOvercurrent = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "poe_faults_fast_overcurrent",
+		Help:      "Number of fast overcurrent PoE faults reported by the WiFi router",
+	}
+	wifiPoeFaultsSlowOvercurrent = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "poe_faults_slow_overcurrent",
+		Help:      "Number of slow overcurrent PoE faults reported by the WiFi router",
+	}
+	wifiPoeFaultsOvervoltage = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "poe_faults_overvoltage",
+		Help:      "Number of overvoltage PoE faults reported by the WiFi router",
+	}
+	wifiPoeFaultsUndervoltage = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "poe_faults_undervoltage",
+		Help:      "Number of undervoltage PoE faults reported by the WiFi router",
+	}
+	wifiPoeVsnsVinVolts = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "poe_vsns_vin_volts",
+		Help:      "Starlink WiFi router PoE input voltage in volts",
+	}
+
+	// Setup requirement
+	wifiSetupRequirementState = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "setup_requirement_state",
+		Help:      "Starlink WiFi router setup requirement state",
+	}
+	wifiSetupRequirementPauseCountdownSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: wifiSubsystem,
+		Name:      "setup_requirement_pause_countdown_seconds",
+		Help:      "Seconds remaining before the WiFi router setup requirement pause expires",
+	}
 )
 
 // Descs contains all Prometheus metrics descriptors for the exporter.
@@ -990,6 +1371,65 @@ var Descs = []*Desc{
 	dishLocationUncertaintyMeters,
 	dishHorizontalSpeedMps,
 	dishVerticalSpeedMps,
+	wifiUp,
+	wifiInfo,
+	wifiUptimeSeconds,
+	wifiHopsFromController,
+	wifiNoWanLink,
+	wifiIsAviation,
+	wifiIsAviationConformed,
+	wifiUsingIndividualizedCalibration,
+	wifiCalibrationPartitionsState,
+	wifiDishDisablementCode,
+	wifiSecsSinceLastPublicIpv4Change,
+	wifiClientsCount,
+	wifiDhcpServersCount,
+	wifiPingDropRatio,
+	wifiPingDropRatio5m,
+	wifiPingLatencySeconds,
+	wifiDishPingDropRatio,
+	wifiDishPingDropRatio5m,
+	wifiDishPingLatencySeconds,
+	wifiPopPingDropRatio,
+	wifiPopPingDropRatio5m,
+	wifiPopPingLatencySeconds,
+	wifiPopIpv6PingDropRatio,
+	wifiPopIpv6PingDropRatio5m,
+	wifiPopIpv6PingLatencySeconds,
+	wifiAlertThermalThrottle,
+	wifiAlertInstallPending,
+	wifiAlertFreshlyFused,
+	wifiAlertLanEthSlowLink10,
+	wifiAlertLanEthSlowLink100,
+	wifiAlertHighCablePingDropRate,
+	wifiAlertWanEthPoorConnection,
+	wifiAlertMeshTopologyChangingOften,
+	wifiAlertMeshUnreliableBackhaul,
+	wifiAlertRadiusMissingProcess,
+	wifiAlertEthSwitchError,
+	wifiAlertPoeOnDishUnreachable,
+	wifiAlertPoeFuseBlown,
+	wifiAlertPoeRouterOvercurrent,
+	wifiAlertPoeOffCurrentNominal,
+	wifiAlertPoeVinOvervoltage,
+	wifiAlertPoeVinUndervoltage,
+	wifiAlertSandboxDisabled,
+	wifiAlertOnlyOverflightBlocked,
+	wifiAlertOfflineNetworksDisabled,
+	wifiAlertWiredMeshNotUsingWanIface,
+	wifiSoftwareUpdateState,
+	wifiSoftwareUpdateDownloadProgress,
+	wifiSoftwareUpdateSecondsSinceGetTargetVersions,
+	wifiSoftwareUpdateInfo,
+	wifiPoeState,
+	wifiPoePowerWatts,
+	wifiPoeFaultsFastOvercurrent,
+	wifiPoeFaultsSlowOvercurrent,
+	wifiPoeFaultsOvervoltage,
+	wifiPoeFaultsUndervoltage,
+	wifiPoeVsnsVinVolts,
+	wifiSetupRequirementState,
+	wifiSetupRequirementPauseCountdownSeconds,
 }
 
 // Desc is a utility wrapper for prometheus.Desc.

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -36,13 +36,21 @@ import (
 // DefaultDishAddress is the default address of the Starlink Dishy's gRPC server.
 const DefaultDishAddress = "192.168.100.1:9200"
 
+// DefaultRouterAddress is the default address of the Starlink WiFi router's
+// gRPC server.
+const DefaultRouterAddress = "192.168.1.1:9000"
+
 // Exporter is a Starlink Dishy metrics exporter.
 type Exporter struct {
 	mx     sync.Mutex
 	conn   *grpc.ClientConn    // Starlink Dishy gRPC connection
 	client device.DeviceClient // Starlink Dishy gRPC client
 
+	wifiConn   *grpc.ClientConn    // Starlink WiFi router gRPC connection (optional)
+	wifiClient device.DeviceClient // Starlink WiFi router gRPC client (optional)
+
 	up                    prometheus.Gauge   // starlink_dish_up
+	wifiUp                prometheus.Gauge   // starlink_wifi_up
 	totalScrapes          prometheus.Counter // starlink_exporter_scrapes_total
 	scrapeDurationSeconds prometheus.Gauge   // starlink_exporter_scrape_duration_seconds
 }
@@ -50,21 +58,26 @@ type Exporter struct {
 var _ prometheus.Collector = (*Exporter)(nil)
 
 // NewExporter returns a new exporter that connects to the Starlink Dishy at
-// the given address.
-func NewExporter(address string) (*Exporter, error) {
+// the given address. If routerAddress is non-empty, the exporter also scrapes
+// WiFi router metrics from that address; router scrape failures are logged but
+// do not cause the dish scrape to fail.
+func NewExporter(address, routerAddress string) (*Exporter, error) {
 	slog.Info("Connecting to Starlink Dishy", slog.String("address", address))
 	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, fmt.Errorf("new grpc client: %w", err)
 	}
 
-	client := device.NewDeviceClient(conn)
-	return &Exporter{
+	e := &Exporter{
 		conn:   conn,
-		client: client,
+		client: device.NewDeviceClient(conn),
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: dishUp.FQName(),
 			Help: dishUp.Help,
+		}),
+		wifiUp: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: wifiUp.FQName(),
+			Help: wifiUp.Help,
 		}),
 		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: exporterScrapesTotal.FQName(),
@@ -74,7 +87,25 @@ func NewExporter(address string) (*Exporter, error) {
 			Name: exporterScrapeDurationSeconds.FQName(),
 			Help: exporterScrapeDurationSeconds.Help,
 		}),
-	}, nil
+	}
+
+	if routerAddress != "" {
+		slog.Info("Connecting to Starlink WiFi router; scrape failures will be handled gracefully",
+			slog.String("address", routerAddress))
+		wifiConn, err := grpc.NewClient(routerAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			if cerr := conn.Close(); cerr != nil {
+				slog.Error("An error occurred while closing dish gRPC connection", slog.Any("err", cerr))
+			}
+			return nil, fmt.Errorf("new wifi grpc client: %w", err)
+		}
+		e.wifiConn = wifiConn
+		e.wifiClient = device.NewDeviceClient(wifiConn)
+	} else {
+		slog.Info("WiFi router scraping disabled")
+	}
+
+	return e, nil
 }
 
 // ConnState returns the gRPC connection state.
@@ -97,14 +128,24 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	up := e.scrape(ch)
 	e.up.Set(btof(up))
 
+	if e.wifiClient != nil {
+		e.wifiUp.Set(btof(e.scrapeWifi(ch)))
+		ch <- e.wifiUp
+	}
+
 	ch <- e.up
 	ch <- e.totalScrapes
 	ch <- e.scrapeDurationSeconds
 }
 
-// Close closes the gRPC connection.
+// Close closes the gRPC connections.
 func (e *Exporter) Close() {
 	if err := e.conn.Close(); err != nil {
-		slog.Error("An error occurred while closing gRPC connection", slog.Any("err", err))
+		slog.Error("An error occurred while closing dish gRPC connection", slog.Any("err", err))
+	}
+	if e.wifiConn != nil {
+		if err := e.wifiConn.Close(); err != nil {
+			slog.Error("An error occurred while closing WiFi router gRPC connection", slog.Any("err", err))
+		}
 	}
 }

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -39,12 +39,17 @@ func dishAddress(t *testing.T) string {
 	return addr
 }
 
+func routerAddress(t *testing.T) string {
+	t.Helper()
+	return os.Getenv("STARLINK_ROUTER_ADDR")
+}
+
 func newTestExporter(t *testing.T) *exporter.Exporter {
 	t.Helper()
 	if os.Getenv("STARLINK_INTEGRATION") == "" {
 		t.Skip("set STARLINK_INTEGRATION=1 to run integration tests")
 	}
-	ex, err := exporter.NewExporter(dishAddress(t))
+	ex, err := exporter.NewExporter(dishAddress(t), routerAddress(t))
 	if err != nil {
 		t.Fatalf("NewExporter: %v", err)
 	}

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -23,6 +23,7 @@ package exporter
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
@@ -53,6 +54,11 @@ var (
 		Name:    dishPowerInputHistogram.FQName(),
 		Help:    dishPowerInputHistogram.Help,
 		Buckets: []float64{20, 25, 30, 40, 50, 75, 100, 150, 200},
+	}
+	dishPopPingDropRatioHistOpts = prometheus.HistogramOpts{
+		Name:    dishPopPingDropRatioHistogram.FQName(),
+		Help:    dishPopPingDropRatioHistogram.Help,
+		Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1},
 	}
 )
 
@@ -221,6 +227,202 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 	ch <- metric(dishAlertSignalLowerThanPredicted, prometheus.GaugeValue,
 		btof(alerts.GetLowerSignalThanPredicted()))
 
+	// Additional alerts
+	ch <- metric(dishAlertMotorsStuck, prometheus.GaugeValue,
+		btof(alerts.GetMotorsStuck()))
+	ch <- metric(dishAlertThermalThrottle, prometheus.GaugeValue,
+		btof(alerts.GetThermalThrottle()))
+	ch <- metric(dishAlertThermalShutdown, prometheus.GaugeValue,
+		btof(alerts.GetThermalShutdown()))
+	ch <- metric(dishAlertMastNotNearVertical, prometheus.GaugeValue,
+		btof(alerts.GetMastNotNearVertical()))
+	ch <- metric(dishAlertSlowEthernetSpeeds, prometheus.GaugeValue,
+		btof(alerts.GetSlowEthernetSpeeds()))
+	ch <- metric(dishAlertSlowEthernetSpeeds100, prometheus.GaugeValue,
+		btof(alerts.GetSlowEthernetSpeeds_100()))
+	ch <- metric(dishAlertRoaming, prometheus.GaugeValue,
+		btof(alerts.GetRoaming()))
+	ch <- metric(dishAlertPowerSupplyThermalThrottle, prometheus.GaugeValue,
+		btof(alerts.GetPowerSupplyThermalThrottle()))
+	ch <- metric(dishAlertDbfTelemStale, prometheus.GaugeValue,
+		btof(alerts.GetDbfTelemStale()))
+	ch <- metric(dishAlertLowMotorCurrent, prometheus.GaugeValue,
+		btof(alerts.GetLowMotorCurrent()))
+	ch <- metric(dishAlertObstructionMapReset, prometheus.GaugeValue,
+		btof(alerts.GetObstructionMapReset()))
+	ch <- metric(dishAlertDishWaterDetected, prometheus.GaugeValue,
+		btof(alerts.GetDishWaterDetected()))
+	ch <- metric(dishAlertRouterWaterDetected, prometheus.GaugeValue,
+		btof(alerts.GetRouterWaterDetected()))
+	ch <- metric(dishAlertUpsuRouterPortSlow, prometheus.GaugeValue,
+		btof(alerts.GetUpsuRouterPortSlow()))
+	ch <- metric(dishAlertNoEthernetLink, prometheus.GaugeValue,
+		btof(alerts.GetNoEthernetLink()))
+
+	// Top-level status scalars
+	ch <- metric(dishSecondsToFirstNonemptySlot, prometheus.GaugeValue,
+		dishStatus.GetSecondsToFirstNonemptySlot())
+	ch <- metric(dishStowRequested, prometheus.GaugeValue,
+		btof(dishStatus.GetStowRequested()))
+	ch <- metric(dishEthSpeedMbps, prometheus.GaugeValue,
+		dishStatus.GetEthSpeedMbps())
+	ch <- metric(dishClassOfService, prometheus.GaugeValue,
+		dishStatus.GetClassOfService())
+	ch <- metric(dishRebootReason, prometheus.GaugeValue,
+		dishStatus.GetRebootReason())
+	ch <- metric(dishDisablementCode, prometheus.GaugeValue,
+		dishStatus.GetDisablementCode())
+	ch <- metric(dishDlBandwidthRestrictedReason, prometheus.GaugeValue,
+		dishStatus.GetDlBandwidthRestrictedReason())
+	ch <- metric(dishUlBandwidthRestrictedReason, prometheus.GaugeValue,
+		dishStatus.GetUlBandwidthRestrictedReason())
+	ch <- metric(dishIsCellDisabled, prometheus.GaugeValue,
+		btof(dishStatus.GetIsCellDisabled()))
+	ch <- metric(dishSecondsUntilSwupdateRebootPossible, prometheus.GaugeValue,
+		dishStatus.GetSecondsUntilSwupdateRebootPossible())
+	ch <- metric(dishHighPowerTestMode, prometheus.GaugeValue,
+		btof(dishStatus.GetHighPowerTestMode()))
+	ch <- metric(dishIsMovingFastPersisted, prometheus.GaugeValue,
+		btof(dishStatus.GetIsMovingFastPersisted()))
+	ch <- metric(dishMacFlag, prometheus.GaugeValue,
+		btof(dishStatus.GetMacFlag()))
+	ch <- metric(dishNatFlag, prometheus.GaugeValue,
+		dishStatus.GetNatFlag())
+	ch <- metric(dishAccountShard, prometheus.GaugeValue,
+		dishStatus.GetAccountShard())
+	ch <- metric(dishConnectedRoutersCount, prometheus.GaugeValue,
+		len(dishStatus.GetConnectedRouters()))
+	ch <- metric(dishHasActuators, prometheus.GaugeValue,
+		dishStatus.GetHasActuators())
+
+	// NED-to-dish orientation quaternion
+	quat := dishStatus.GetNed2DishQuaternion()
+	ch <- metric(dishNed2DishQuaternionW, prometheus.GaugeValue, quat.GetQScalar())
+	ch <- metric(dishNed2DishQuaternionX, prometheus.GaugeValue, quat.GetQX())
+	ch <- metric(dishNed2DishQuaternionY, prometheus.GaugeValue, quat.GetQY())
+	ch <- metric(dishNed2DishQuaternionZ, prometheus.GaugeValue, quat.GetQZ())
+
+	// Current outage
+	if outage := dishStatus.GetOutage(); outage != nil {
+		ch <- metric(dishOutageInfo, prometheus.GaugeValue, 1,
+			outage.GetCause().String(),
+			strconv.FormatBool(outage.GetDidSwitch()),
+		)
+		ch <- metric(dishOutageStartTimestampSeconds, prometheus.GaugeValue,
+			float64(outage.GetStartTimestampNs())/1e9)
+		ch <- metric(dishOutageDurationSeconds, prometheus.GaugeValue,
+			float64(outage.GetDurationNs())/1e9)
+	}
+
+	// GPS (additional)
+	ch <- metric(dishGPSNoSatsAfterTtff, prometheus.GaugeValue,
+		btof(dishStatus.GetGpsStats().GetNoSatsAfterTtff()))
+	ch <- metric(dishGPSInhibit, prometheus.GaugeValue,
+		btof(dishStatus.GetGpsStats().GetInhibitGps()))
+
+	// Obstruction (additional)
+	ch <- metric(dishObstructionValidSeconds, prometheus.GaugeValue,
+		obstructionStats.GetValidS())
+	ch <- metric(dishObstructionPatchesValid, prometheus.GaugeValue,
+		obstructionStats.GetPatchesValid())
+	ch <- metric(dishAvgProlongedObstructionDurationSeconds, prometheus.GaugeValue,
+		obstructionStats.GetAvgProlongedObstructionDurationS())
+	ch <- metric(dishAvgProlongedObstructionIntervalSeconds, prometheus.GaugeValue,
+		obstructionStats.GetAvgProlongedObstructionIntervalS())
+	ch <- metric(dishAvgProlongedObstructionValid, prometheus.GaugeValue,
+		btof(obstructionStats.GetAvgProlongedObstructionValid()))
+
+	// Ready states
+	ready := dishStatus.GetReadyStates()
+	ch <- metric(dishReadyStateCady, prometheus.GaugeValue, btof(ready.GetCady()))
+	ch <- metric(dishReadyStateScp, prometheus.GaugeValue, btof(ready.GetScp()))
+	ch <- metric(dishReadyStateL1L2, prometheus.GaugeValue, btof(ready.GetL1L2()))
+	ch <- metric(dishReadyStateXphy, prometheus.GaugeValue, btof(ready.GetXphy()))
+	ch <- metric(dishReadyStateAap, prometheus.GaugeValue, btof(ready.GetAap()))
+	ch <- metric(dishReadyStateRf, prometheus.GaugeValue, btof(ready.GetRf()))
+
+	// Software update stats
+	swStats := dishStatus.GetSoftwareUpdateStats()
+	ch <- metric(dishSoftwareUpdateProgress, prometheus.GaugeValue,
+		swStats.GetSoftwareUpdateProgress())
+	ch <- metric(dishSoftwareUpdateRequiresReboot, prometheus.GaugeValue,
+		btof(swStats.GetUpdateRequiresReboot()))
+	ch <- metric(dishSoftwareUpdateRebootScheduledUtcSeconds, prometheus.GaugeValue,
+		swStats.GetRebootScheduledUtcTime())
+
+	// Alignment (additional)
+	alignment := dishStatus.GetAlignmentStats()
+	ch <- metric(dishActuatorState, prometheus.GaugeValue,
+		alignment.GetActuatorState())
+	ch <- metric(dishAttitudeEstimationState, prometheus.GaugeValue,
+		alignment.GetAttitudeEstimationState())
+	ch <- metric(dishAttitudeUncertaintyDeg, prometheus.GaugeValue,
+		alignment.GetAttitudeUncertaintyDeg())
+
+	// Initialization durations
+	init := dishStatus.GetInitializationDurationSeconds()
+	ch <- metric(dishInitAttitudeSeconds, prometheus.GaugeValue,
+		init.GetAttitudeInitialization())
+	ch <- metric(dishInitBurstDetectedSeconds, prometheus.GaugeValue,
+		init.GetBurstDetected())
+	ch <- metric(dishInitEkfConvergedSeconds, prometheus.GaugeValue,
+		init.GetEkfConverged())
+	ch <- metric(dishInitFirstCplaneSeconds, prometheus.GaugeValue,
+		init.GetFirstCplane())
+	ch <- metric(dishInitFirstPopPingSeconds, prometheus.GaugeValue,
+		init.GetFirstPopPing())
+	ch <- metric(dishInitGpsValidSeconds, prometheus.GaugeValue,
+		init.GetGpsValid())
+	ch <- metric(dishInitInitialNetworkEntrySeconds, prometheus.GaugeValue,
+		init.GetInitialNetworkEntry())
+	ch <- metric(dishInitNetworkScheduleSeconds, prometheus.GaugeValue,
+		init.GetNetworkSchedule())
+	ch <- metric(dishInitRfReadySeconds, prometheus.GaugeValue,
+		init.GetRfReady())
+	ch <- metric(dishInitStableConnectionSeconds, prometheus.GaugeValue,
+		init.GetStableConnection())
+
+	// PLC (Mini battery)
+	plc := dishStatus.GetPlcStats()
+	ch <- metric(dishPlcReceiving, prometheus.GaugeValue,
+		btof(plc.GetReceivingPlc()))
+	ch <- metric(dishPlcAverageTimeToEmptySeconds, prometheus.GaugeValue,
+		plc.GetAverageTimeToEmpty())
+	ch <- metric(dishPlcAverageTimeToFullSeconds, prometheus.GaugeValue,
+		plc.GetAverageTimeToFull())
+	ch <- metric(dishPlcBatteryHealth, prometheus.GaugeValue,
+		plc.GetBatteryHealth())
+	ch <- metric(dishPlcPermanentFailure, prometheus.GaugeValue,
+		btof(plc.GetPermanentFailure()))
+	ch <- metric(dishPlcSafetyModeActive, prometheus.GaugeValue,
+		btof(plc.GetSafetyModeActive()))
+	ch <- metric(dishPlcStateOfChargePercent, prometheus.GaugeValue,
+		plc.GetStateOfCharge())
+	ch <- metric(dishPlcThermalThrottleLevel, prometheus.GaugeValue,
+		plc.GetThermalThrottleLevel())
+	ch <- metric(dishPlcRevision, prometheus.GaugeValue,
+		plc.GetPlcRevision())
+
+	// UPSU
+	upsu := dishStatus.GetUpsuStats()
+	ch <- metric(dishUpsuDishPowerWatts, prometheus.GaugeValue,
+		upsu.GetDishPower())
+	ch <- metric(dishUpsuRouterPowerWatts, prometheus.GaugeValue,
+		upsu.GetRouterPower())
+	ch <- metric(dishUpsuUptimeSeconds, prometheus.GaugeValue,
+		upsu.GetUptime())
+	ch <- metric(dishUpsuBoardRev, prometheus.GaugeValue,
+		upsu.GetBoardRev())
+
+	// APS
+	aps := dishStatus.GetApsStats()
+	ch <- metric(dishApsDishPowerWatts, prometheus.GaugeValue,
+		aps.GetDishPower())
+	ch <- metric(dishApsUptimeSeconds, prometheus.GaugeValue,
+		aps.GetUptime())
+	ch <- metric(dishApsBoardRev, prometheus.GaugeValue,
+		aps.GetBoardRev())
+
 	return true
 }
 
@@ -285,6 +487,18 @@ func (e *Exporter) scrapeDishHistory(ctx context.Context, ch chan<- prometheus.M
 			powerData[len(powerData)-1])
 	}
 
+	// starlink_dish_pop_ping_drop_ratio_histogram
+	dropData := parseRingBuffer(dishHistory.GetPopPingDropRate(), dishHistory.GetCurrent())
+	dropHist := prometheus.NewHistogram(dishPopPingDropRatioHistOpts)
+	for _, drop := range dropData {
+		dropHist.Observe(float64(drop))
+	}
+	ch <- dropHist
+
+	// starlink_dish_history_outages_count
+	ch <- metric(dishHistoryOutagesCount, prometheus.GaugeValue,
+		len(dishHistory.GetOutages()))
+
 	return true
 }
 
@@ -321,6 +535,15 @@ func (e *Exporter) scrapeLocation(ctx context.Context, ch chan<- prometheus.Metr
 
 	// starlink_dish_location_altitude_meters
 	ch <- metric(dishLocationAltitude, prometheus.GaugeValue, lla.GetAlt())
+
+	// starlink_dish_location_uncertainty_meters
+	ch <- metric(dishLocationUncertaintyMeters, prometheus.GaugeValue, loc.GetSigmaM())
+
+	// starlink_dish_horizontal_speed_mps
+	ch <- metric(dishHorizontalSpeedMps, prometheus.GaugeValue, loc.GetHorizontalSpeedMps())
+
+	// starlink_dish_vertical_speed_mps
+	ch <- metric(dishVerticalSpeedMps, prometheus.GaugeValue, loc.GetVerticalSpeedMps())
 
 	return true
 }

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -547,3 +547,123 @@ func (e *Exporter) scrapeLocation(ctx context.Context, ch chan<- prometheus.Metr
 
 	return true
 }
+
+// scrapeWifi scrapes metrics from the WiFi router's GetStatus response. It
+// runs independently of the dish scrape; failures are logged but do not
+// affect starlink_dish_up.
+func (e *Exporter) scrapeWifi(ch chan<- prometheus.Metric) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	res, err := e.wifiClient.Handle(ctx, &device.Request{
+		Request: new(device.Request_GetStatus),
+	})
+	if err != nil {
+		slog.Error("Failed to scrape WiFi router status", slog.Any("err", err))
+		return false
+	}
+
+	wifiStatus := res.GetWifiGetStatus()
+	deviceInfo := wifiStatus.GetDeviceInfo()
+	deviceState := wifiStatus.GetDeviceState()
+	alerts := wifiStatus.GetAlerts()
+
+	// starlink_wifi_info
+	ch <- metric(wifiInfo, prometheus.GaugeValue, 1,
+		deviceInfo.GetId(),
+		deviceInfo.GetHardwareVersion(),
+		itos(deviceInfo.GetBoardRev()),
+		deviceInfo.GetSoftwareVersion(),
+		deviceInfo.GetManufacturedVersion(),
+		itos(deviceInfo.GetGenerationNumber()),
+		deviceInfo.GetCountryCode(),
+		itos(deviceInfo.GetUtcOffsetS()),
+		itos(deviceInfo.GetBootcount()),
+	)
+
+	ch <- metric(wifiUptimeSeconds, prometheus.GaugeValue, deviceState.GetUptimeS())
+	ch <- metric(wifiHopsFromController, prometheus.GaugeValue, wifiStatus.GetHopsFromController())
+	ch <- metric(wifiNoWanLink, prometheus.GaugeValue, btof(wifiStatus.GetNoWanLink()))
+	ch <- metric(wifiIsAviation, prometheus.GaugeValue, btof(wifiStatus.GetIsAviation()))
+	ch <- metric(wifiIsAviationConformed, prometheus.GaugeValue, btof(wifiStatus.GetIsAviationConformed()))
+	ch <- metric(wifiUsingIndividualizedCalibration, prometheus.GaugeValue,
+		btof(wifiStatus.GetUsingIndividualizedCalibration()))
+	ch <- metric(wifiCalibrationPartitionsState, prometheus.GaugeValue,
+		wifiStatus.GetCalibrationPartitionsState())
+	ch <- metric(wifiDishDisablementCode, prometheus.GaugeValue,
+		wifiStatus.GetDishDisablementCode())
+	ch <- metric(wifiSecsSinceLastPublicIpv4Change, prometheus.GaugeValue,
+		wifiStatus.GetSecsSinceLastPublicIpv4Change())
+	ch <- metric(wifiClientsCount, prometheus.GaugeValue, len(wifiStatus.GetClients()))
+	ch <- metric(wifiDhcpServersCount, prometheus.GaugeValue, len(wifiStatus.GetDhcpServers()))
+
+	// Ping (drop rates are already ratios; latencies are milliseconds → seconds).
+	ch <- metric(wifiPingDropRatio, prometheus.GaugeValue, wifiStatus.GetPingDropRate())
+	ch <- metric(wifiPingDropRatio5m, prometheus.GaugeValue, wifiStatus.GetPingDropRate_5M())
+	ch <- metric(wifiPingLatencySeconds, prometheus.GaugeValue, wifiStatus.GetPingLatencyMs()/1000)
+	ch <- metric(wifiDishPingDropRatio, prometheus.GaugeValue, wifiStatus.GetDishPingDropRate())
+	ch <- metric(wifiDishPingDropRatio5m, prometheus.GaugeValue, wifiStatus.GetDishPingDropRate_5M())
+	ch <- metric(wifiDishPingLatencySeconds, prometheus.GaugeValue, wifiStatus.GetDishPingLatencyMs()/1000)
+	ch <- metric(wifiPopPingDropRatio, prometheus.GaugeValue, wifiStatus.GetPopPingDropRate())
+	ch <- metric(wifiPopPingDropRatio5m, prometheus.GaugeValue, wifiStatus.GetPopPingDropRate_5M())
+	ch <- metric(wifiPopPingLatencySeconds, prometheus.GaugeValue, wifiStatus.GetPopPingLatencyMs()/1000)
+	ch <- metric(wifiPopIpv6PingDropRatio, prometheus.GaugeValue, wifiStatus.GetPopIpv6PingDropRate())
+	ch <- metric(wifiPopIpv6PingDropRatio5m, prometheus.GaugeValue, wifiStatus.GetPopIpv6PingDropRate_5M())
+	ch <- metric(wifiPopIpv6PingLatencySeconds, prometheus.GaugeValue, wifiStatus.GetPopIpv6PingLatencyMs()/1000)
+
+	// Alerts
+	ch <- metric(wifiAlertThermalThrottle, prometheus.GaugeValue, btof(alerts.GetThermalThrottle()))
+	ch <- metric(wifiAlertInstallPending, prometheus.GaugeValue, btof(alerts.GetInstallPending()))
+	ch <- metric(wifiAlertFreshlyFused, prometheus.GaugeValue, btof(alerts.GetFreshlyFused()))
+	ch <- metric(wifiAlertLanEthSlowLink10, prometheus.GaugeValue, btof(alerts.GetLanEthSlowLink_10()))
+	ch <- metric(wifiAlertLanEthSlowLink100, prometheus.GaugeValue, btof(alerts.GetLanEthSlowLink_100()))
+	ch <- metric(wifiAlertHighCablePingDropRate, prometheus.GaugeValue, btof(alerts.GetHighCablePingDropRate()))
+	ch <- metric(wifiAlertWanEthPoorConnection, prometheus.GaugeValue, btof(alerts.GetWanEthPoorConnection()))
+	ch <- metric(wifiAlertMeshTopologyChangingOften, prometheus.GaugeValue,
+		btof(alerts.GetMeshTopologyChangingOften()))
+	ch <- metric(wifiAlertMeshUnreliableBackhaul, prometheus.GaugeValue, btof(alerts.GetMeshUnreliableBackhaul()))
+	ch <- metric(wifiAlertRadiusMissingProcess, prometheus.GaugeValue, btof(alerts.GetRadiusMissingProcess()))
+	ch <- metric(wifiAlertEthSwitchError, prometheus.GaugeValue, btof(alerts.GetEthSwitchError()))
+	ch <- metric(wifiAlertPoeOnDishUnreachable, prometheus.GaugeValue, btof(alerts.GetPoeOnDishUnreachable()))
+	ch <- metric(wifiAlertPoeFuseBlown, prometheus.GaugeValue, btof(alerts.GetPoeFuseBlown()))
+	ch <- metric(wifiAlertPoeRouterOvercurrent, prometheus.GaugeValue, btof(alerts.GetPoeRouterOvercurrent()))
+	ch <- metric(wifiAlertPoeOffCurrentNominal, prometheus.GaugeValue, btof(alerts.GetPoeOffCurrentNominal()))
+	ch <- metric(wifiAlertPoeVinOvervoltage, prometheus.GaugeValue, btof(alerts.GetPoeVinOvervoltage()))
+	ch <- metric(wifiAlertPoeVinUndervoltage, prometheus.GaugeValue, btof(alerts.GetPoeVinUndervoltage()))
+	ch <- metric(wifiAlertSandboxDisabled, prometheus.GaugeValue, btof(alerts.GetSandboxDisabled()))
+	ch <- metric(wifiAlertOnlyOverflightBlocked, prometheus.GaugeValue, btof(alerts.GetOnlyOverflightBlocked()))
+	ch <- metric(wifiAlertOfflineNetworksDisabled, prometheus.GaugeValue,
+		btof(alerts.GetOfflineNetworksDisabled()))
+	ch <- metric(wifiAlertWiredMeshNotUsingWanIface, prometheus.GaugeValue,
+		btof(alerts.GetWiredMeshNotUsingWanIface()))
+
+	// Software update
+	swStats := wifiStatus.GetSoftwareUpdateStats()
+	ch <- metric(wifiSoftwareUpdateState, prometheus.GaugeValue, swStats.GetState())
+	ch <- metric(wifiSoftwareUpdateDownloadProgress, prometheus.GaugeValue,
+		swStats.GetSoftwareDownloadProgress())
+	ch <- metric(wifiSoftwareUpdateSecondsSinceGetTargetVersions, prometheus.GaugeValue,
+		swStats.GetSecondsSinceGetTargetVersions())
+	ch <- metric(wifiSoftwareUpdateInfo, prometheus.GaugeValue, 1,
+		swStats.GetRunningVersion(),
+		swStats.GetVersionInProgress(),
+	)
+
+	// PoE
+	poe := wifiStatus.GetPoeStats()
+	ch <- metric(wifiPoeState, prometheus.GaugeValue, poe.GetPoeState())
+	ch <- metric(wifiPoePowerWatts, prometheus.GaugeValue, poe.GetPoePower())
+	ch <- metric(wifiPoeFaultsFastOvercurrent, prometheus.GaugeValue, poe.GetPoeFaultsFastOvercurrent())
+	ch <- metric(wifiPoeFaultsSlowOvercurrent, prometheus.GaugeValue, poe.GetPoeFaultsSlowOvercurrent())
+	ch <- metric(wifiPoeFaultsOvervoltage, prometheus.GaugeValue, poe.GetPoeFaultsOvervoltage())
+	ch <- metric(wifiPoeFaultsUndervoltage, prometheus.GaugeValue, poe.GetPoeFaultsUndervoltage())
+	ch <- metric(wifiPoeVsnsVinVolts, prometheus.GaugeValue, poe.GetVsnsVin())
+
+	// Setup requirement
+	setup := wifiStatus.GetSetupRequirement()
+	ch <- metric(wifiSetupRequirementState, prometheus.GaugeValue, setup.GetState())
+	ch <- metric(wifiSetupRequirementPauseCountdownSeconds, prometheus.GaugeValue,
+		setup.GetPauseCountdownSeconds())
+
+	return true
+}


### PR DESCRIPTION
This adds an additional set of metrics which are exposed by the dish. This also adds the ability to fetch router information such as WiFi connection quality information. If the user specifies a empty router config, or it fails to connect to the router (I.e. passthrough mode to a customer supplied router) it will gracefully fail. 

**Dish Attributes added (all under starlink_dish_*):**

  Dish alerts (15)
  - alert_motors_stuck, alert_thermal_throttle, alert_thermal_shutdown, alert_mast_not_near_vertical,
  alert_slow_ethernet_speeds, alert_slow_ethernet_speeds_100, alert_roaming, alert_power_supply_thermal_throttle,
  alert_dbf_telem_stale, alert_low_motor_current, alert_obstruction_map_reset, alert_dish_water_detected,
  alert_router_water_detected, alert_upsu_router_port_slow, alert_no_ethernet_link

  Status / top-level (21)
  - seconds_to_first_nonempty_slot, stow_requested, eth_speed_mbps, class_of_service, reboot_reason, disablement_code,
  dl_bandwidth_restricted_reason, ul_bandwidth_restricted_reason, is_cell_disabled, seconds_until_swupdate_reboot_possible,
  high_power_test_mode, is_moving_fast_persisted, mac_flag, nat_flag, account_shard, connected_routers_count, has_actuators,
  ned2dish_quaternion_{w,x,y,z}

  Current outage (3)
  - outage_info (labels: cause, did_switch), outage_start_timestamp_seconds, outage_duration_seconds

  GPS (2)
  - gps_no_sats_after_ttff, gps_inhibit

  Obstruction (5)
  - obstruction_valid_seconds, obstruction_patches_valid, avg_prolonged_obstruction_duration_seconds,
  avg_prolonged_obstruction_interval_seconds, avg_prolonged_obstruction_valid

  Ready states (6)
  - ready_state_cady, ready_state_scp, ready_state_l1l2, ready_state_xphy, ready_state_aap, ready_state_rf

  Software update (3)
  - software_update_progress, software_update_requires_reboot, software_update_reboot_scheduled_utc_seconds

  Alignment (3)
  - actuator_state, attitude_estimation_state, attitude_uncertainty_deg

  Initialization durations (10)
  - initialization_attitude_seconds, initialization_burst_detected_seconds, initialization_ekf_converged_seconds,
  initialization_first_cplane_seconds, initialization_first_pop_ping_seconds, initialization_gps_valid_seconds,
  initialization_initial_network_entry_seconds, initialization_network_schedule_seconds, initialization_rf_ready_seconds,
  initialization_stable_connection_seconds

  PLC / Mini battery (9)
  - plc_receiving, plc_average_time_to_empty_seconds, plc_average_time_to_full_seconds, plc_battery_health,
  plc_permanent_failure, plc_safety_mode_active, plc_state_of_charge_percent, plc_thermal_throttle_level, plc_revision

  UPSU (Gen 3 power supply, 4)
  - upsu_dish_power_watts, upsu_router_power_watts, upsu_uptime_seconds, upsu_board_rev

  APS (auxiliary power supply, 3)
  - aps_dish_power_watts, aps_uptime_seconds, aps_board_rev

  History (2)
  - pop_ping_drop_ratio_histogram, history_outages_count

  Location (3)
  - location_uncertainty_meters, horizontal_speed_mps, vertical_speed_mps

**Wifi Attributes Added (all under starlink_wifi_*):**
  Connection / scrape (1)
  - starlink_wifi_up

  Router info & status (10)
  - info, uptime_seconds, hops_from_controller, no_wan_link, is_aviation, is_aviation_conformed,
  using_individualized_calibration, calibration_partitions_state, dish_disablement_code, seconds_since_last_public_ipv4_change

  Clients / network (2)
  - clients_count, dhcp_servers_count

  Ping / latency (9)
  - ping_drop_ratio, ping_drop_ratio_5m, ping_latency_seconds
  - dish_ping_drop_ratio, dish_ping_drop_ratio_5m, dish_ping_latency_seconds
  - pop_ping_drop_ratio, pop_ping_drop_ratio_5m, pop_ping_latency_seconds
  - pop_ipv6_ping_drop_ratio, pop_ipv6_ping_drop_ratio_5m, pop_ipv6_ping_latency_seconds

  Alerts (21)
  - alert_thermal_throttle, alert_install_pending, alert_freshly_fused, alert_lan_eth_slow_link_10,
  alert_lan_eth_slow_link_100, alert_high_cable_ping_drop_rate, alert_wan_eth_poor_connection,
  alert_mesh_topology_changing_often, alert_mesh_unreliable_backhaul, alert_radius_missing_process, alert_eth_switch_error,
  alert_poe_on_dish_unreachable, alert_poe_fuse_blown, alert_poe_router_overcurrent, alert_poe_off_current_nominal,
  alert_poe_vin_overvoltage, alert_poe_vin_undervoltage, alert_sandbox_disabled, alert_only_overflight_blocked,
  alert_offline_networks_disabled, alert_wired_mesh_not_using_wan_iface

  Software update (4)
  - software_update_state, software_update_download_progress, software_update_seconds_since_get_target_versions,
  software_update_info

  PoE (7)
  - poe_state, poe_power_watts, poe_faults_fast_overcurrent, poe_faults_slow_overcurrent, poe_faults_overvoltage,
  poe_faults_undervoltage, poe_vsns_vin_volts

  Setup (2)
  - setup_requirement_state, setup_requirement_pause_countdown_seconds
