### PR TITLE
ci: improve release artifact reproducibility

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,13 +23,14 @@ env:
   # renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
   GOVULNCHECK_VERSION: "v1.7.0"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   vulncheck:
     name: "Vulnerability Check"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,6 +51,8 @@ jobs:
   build:
     name: "Build and test (${{ matrix.os }})"
     runs-on: "${{ matrix.os }}"
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: ["ubuntu-latest"]
@@ -78,6 +81,8 @@ jobs:
   lint:
     name: "Lint"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -133,3 +138,8 @@ jobs:
 #          fi
 #          echo "$LICENSE_HEADER" > license_header.txt
 #          golicenser -author="Joshua Sing <joshua@joshuasing.dev>" -year-mode=git-range ./...
+
+      - name: "Verify module files are tidy"
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ env:
   # renovate: datasource=github-releases depName=anchore/syft versioning=semver
   SYFT_VERSION: "v1.51.1"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   release:
@@ -45,6 +44,11 @@ jobs:
         with:
           cache: false
           go-version-file: "go.mod"
+
+      - name: "Verify module files are tidy"
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
 
       - name: "Install cosign"
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,6 @@ report_sizes: true
 
 before:
   hooks:
-    - "go mod tidy"
     - "go mod download"
     - "go mod verify"
 
@@ -46,7 +45,7 @@ builds:
         goarch: "arm"
 
 archives:
-  - formats: ["tar.gz", "tar.zst"]
+  - formats: ["tar.gz"]
     wrap_in_directory: true
     name_template: >-
       starlink_exporter_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}
@@ -54,11 +53,28 @@ archives:
       - goos: "windows"
         formats: ["zip"]
     builds_info:
+      owner: root
+      group: root
       mtime: "{{ .CommitDate }}"
     files:
-      - "README*"
-      - "LICENSE*"
-      - "CHANGELOG*"
+      - src: "README.md"
+        info:
+          owner: root
+          group: root
+          mode: 0644
+          mtime: "{{ .CommitDate }}"
+      - src: "LICENSE"
+        info:
+          owner: root
+          group: root
+          mode: 0644
+          mtime: "{{ .CommitDate }}"
+      - src: "CHANGELOG.md"
+        info:
+          owner: root
+          group: root
+          mode: 0644
+          mtime: "{{ .CommitDate }}"
 
 # Create sources archive.
 source:
@@ -106,20 +122,23 @@ dockers_v2:
     platforms:
       - "linux/amd64"
       - "linux/arm64"
+    build_args:
+      SOURCE_DATE_EPOCH: "{{ .CommitTimestamp }}"
     labels:
       "maintainer": "Joshua Sing <joshua@joshuasing.dev>"
-      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.created": "{{ .CommitDate }}"
       "org.opencontainers.image.authors": "Joshua Sing <joshua@joshuasing.dev>"
       "org.opencontainers.image.url": "https://github.com/joshuasing/starlink_exporter"
       "org.opencontainers.image.documentation": "https://github.com/joshuasing/starlink_exporter#readme"
-      "org.opencontainers.image.source": "https://github.com/joshuasing/starlink_exporter"
+      "org.opencontainers.image.source": "{{ .GitURL }}"
       "org.opencontainers.image.version": "{{ .Version }}"
       "org.opencontainers.image.revision": "{{ .FullCommit }}"
       "org.opencontainers.image.licenses": "MIT"
       "org.opencontainers.image.vendor": "Joshua Sing <joshua@joshuasing.dev>"
       "org.opencontainers.image.title": "Starlink Prometheus Exporter"
       "org.opencontainers.image.description": "Prometheus exporter for Starlink"
-      "org.opencontainers.image.base.name": "cgr.dev/chainguard/static"
+      "org.opencontainers.image.base.name": "{{ .BaseImage }}"
+      "org.opencontainers.image.base.digest": "{{ .BaseImageDigest }}"
 
 # Sign Docker images and manifests.
 docker_signs:
@@ -144,7 +163,7 @@ release:
   github:
     owner: "joshuasing"
     name: "starlink_exporter"
-  draft: true
+  draft: true # Manually add changelog, then release.
   replace_existing_draft: true
   prerelease: auto
   header: |
@@ -155,11 +174,15 @@ release:
   footer: |
     ---
 
-    - **Images:**
-      - `ghcr.io/joshuasing/starlink_exporter:{{ .Version }}`
-      - `docker.io/joshuasing/starlink_exporter:{{ .Version }}`
-    - **Build from source:**
-      - `go install github.com/joshuasing/starlink_exporter@v{{ .Version }}`
+    Images:
+    ```
+    ghcr.io/joshuasing/starlink_exporter:{{ .Version }}
+    docker.io/joshuasing/starlink_exporter:{{ .Version }}
+    ```
+    Build from source:
+    ```shell
+    go install github.com/joshuasing/starlink_exporter@v{{ .Version }}
+    ```
 
     All release artifacts are signed with [cosign](https://github.com/sigstore/cosign) and include SBOMs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved release artifact reproducibility and metadata
 - Improved installation and usage documentation ([#266])
 - Updated Go to 1.27 (security) ([#253], [#294])
 - Updated `github.com/prometheus/common` to v0.69.0 ([#245])
 - Updated `github.com/prometheus/exporter-toolkit` to v0.17.1 ([#263])
 - Updated `google.golang.org/grpc` to v1.82.0 ([#264])
 - Updated Docker runtime base image to `cgr.dev/chainguard/static@60582b2` ([#254])
+
+### Removed
+
+- Removed `tar.zst` release archives
 
 ## [v0.9.2] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improved release artifact reproducibility and metadata
+- Improved release artifact reproducibility and metadata ([#295])
 - Improved installation and usage documentation ([#266])
 - Updated Go to 1.27 (security) ([#253], [#294])
 - Updated `github.com/prometheus/common` to v0.69.0 ([#245])
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed `tar.zst` release archives
+- Removed `tar.zst` release archives ([#295])
 
 ## [v0.9.2] - 2026-06-08
 
@@ -177,3 +177,4 @@ https://github.com/joshuasing/starlink_exporter/releases_
 [#265]: https://github.com/joshuasing/starlink_exporter/pull/265
 [#266]: https://github.com/joshuasing/starlink_exporter/pull/266
 [#294]: https://github.com/joshuasing/starlink_exporter/pull/294
+[#295]: https://github.com/joshuasing/starlink_exporter/pull/295


### PR DESCRIPTION
**Summary**
Improve GoReleaser release artifact reproducibility, tidy up

**Changes**
- Normalise release archive ownership, permissions, and timestamps
- Use commit and base-image metadata for container images
- Verify Go module tidiness in CI, avoid modifying files during release
- Remove `tar.zst` release archives (did not reduce file size, largely useless)
- Improve draft release formatting
- Improve workflow permission scoping

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>