### PR TITLE
exporter: add dish power, router power and thermal metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,51 +39,55 @@ Metrics are exposed at `/metrics` in the Prometheus text format.
 <details>
 <summary>View all exported metrics</summary>
 
-| Metric name                                        | Description                                                                   |
-|----------------------------------------------------|-------------------------------------------------------------------------------|
-| `starlink_exporter_scrapes_total`                  | Total number of Starlink dish scrapes                                         |
-| `starlink_exporter_scrape_duration_seconds`        | Time taken to scrape metrics from the Starlink dish                           |
-| `starlink_dish_up`                                 | Whether scraping metrics from the Starlink dish was successful                |
-| `starlink_dish_info`                               | Starlink dish software information                                            |
-| `starlink_dish_uptime_seconds`                     | Starlink dish uptime in seconds                                               |
-| `starlink_dish_mobility_class`                     | Starlink dish mobility class                                                  |
-| `starlink_dish_snr_above_noise_floor`              | Whether Starlink dish signal-to-noise ratio is above noise floor              |
-| `starlink_dish_snr_persistently_low`               | Whether Starlink dish signal-to-noise ratio is persistently low               |
-| `starlink_dish_uplink_throughput_bps`              | Starlink dish uplink throughput in bits/sec                                   |
-| `starlink_dish_downlink_throughput_bps`            | Starlink dish downlink throughput in bit/sec                                  |
-| `starlink_dish_downlink_throughput_bps_histogram`  | Histogram of Starlink dish downlink throughput over last 15 minutes           |
-| `starlink_dish_uplink_throughput_bps_histogram`    | Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes |
-| `starlink_dish_pop_ping_drop_ratio`                | Starlink PoP ping drop ratio                                                  |
-| `starlink_dish_pop_ping_latency_seconds`           | Starlink PoP ping latency in seconds                                          |
-| `starlink_dish_pop_ping_latency_seconds_histogram` | Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes   |
-| `starlink_dish_software_update_state`              | Starlink dish update state                                                    |
-| `starlink_dish_software_update_reboot_ready`       | Whether the Starlink dish is ready to reboot to apply a software update       |
-| `starlink_dish_gps_valid`                          | Whether the Starlink dish GPS is valid                                        |
-| `starlink_dish_gps_satellites`                     | Number of GPS satellites visible to the Starlink dish                         |
-| `starlink_dish_tilt_angle_deg`                     | Starlink dish tilt angle degrees                                              |
-| `starlink_dish_boresight_azimuth_deg`              | Starlink dish boresight azimuth degrees                                       |
-| `starlink_dish_boresight_elevation_deg`            | Starlink dish boresight elevation degrees                                     |
-| `starlink_dish_desired_boresight_azimuth_deg`      | Starlink dish desired boresight azimuth degrees                               |
-| `starlink_dish_desired_boresight_elevation_deg`    | Starlink dish desired boresight elevation degrees                             |
-| `starlink_dish_currently_obstructed`               | Whether the Starlink dish is currently obstructed                             |
-| `starlink_dish_fraction_obstruction_ratio`         | Fraction of Starlink dish that is obstructed                                  |
-| `starlink_dish_last_24h_obstructed_seconds`        | Number of seconds the Starlink dish was obstructed in the past 24 hours       |
-| `starlink_dish_power_input_watts_histogram`        | Histogram of Starlink dish power input in watts over last 15 minutes          |
-| `starlink_dish_power_input_watts`                  | Current power input for the Starlink dish                                     |
-| `starlink_dish_power_watts`                        | Real-time Starlink dish power draw in watts, by power supply                  |
-| `starlink_dish_router_power_watts`                 | Real-time Starlink WiFi router power draw in watts                            |
-| `starlink_dish_upsu_uptime_seconds`                | Starlink UPSU power supply uptime in seconds                                  |
-| `starlink_dish_thermal_throttle_level`             | Starlink dish thermal throttle level (0 is unthrottled)                       |
-| `starlink_dish_high_power_test_mode`               | Whether Starlink dish max-power test mode is active                           |
-| `starlink_dish_location_info`                      | Dish location information                                                     |
-| `starlink_dish_location_latitude_deg`              | Location latitude in degrees                                                  |
-| `starlink_dish_location_longitude_deg`             | Location longitude in degrees                                                 |
-| `starlink_dish_location_altitude_meters`           | Location altitude in meters above sea level                                   |
-| `starlink_dish_alert_unexpected_location`          | Whether the Starlink dish is in an unexpected location                        |
-| `starlink_dish_alert_install_pending`              | Whether a Starlink Dish software update is pending installation               |
-| `starlink_dish_alert_is_heating`                   | Whether the Starlink dish is heating (snow melting)                           |
-| `starlink_dish_alert_is_power_save_idle`           | Whether the Starlink dish is currently in power saving mode                   |
-| `starlink_dish_alert_signal_lower_than_predicted`  | Whether the Starlink dish signal is lower than predicted                      |
+| Metric name                                         | Description                                                                   |
+|-----------------------------------------------------|-------------------------------------------------------------------------------|
+| `starlink_exporter_scrapes_total`                   | Total number of Starlink dish scrapes                                         |
+| `starlink_exporter_scrape_duration_seconds`         | Time taken to scrape metrics from the Starlink dish                           |
+| `starlink_dish_up`                                  | Whether scraping metrics from the Starlink dish was successful                |
+| `starlink_dish_info`                                | Starlink dish software information                                            |
+| `starlink_dish_uptime_seconds`                      | Starlink dish uptime in seconds                                               |
+| `starlink_dish_mobility_class`                      | Starlink dish mobility class                                                  |
+| `starlink_dish_snr_above_noise_floor`               | Whether Starlink dish signal-to-noise ratio is above noise floor              |
+| `starlink_dish_snr_persistently_low`                | Whether Starlink dish signal-to-noise ratio is persistently low               |
+| `starlink_dish_uplink_throughput_bps`               | Starlink dish uplink throughput in bits/sec                                   |
+| `starlink_dish_downlink_throughput_bps`             | Starlink dish downlink throughput in bit/sec                                  |
+| `starlink_dish_downlink_throughput_bps_histogram`   | Histogram of Starlink dish downlink throughput over last 15 minutes           |
+| `starlink_dish_uplink_throughput_bps_histogram`     | Histogram of Starlink dish uplink throughput in bits/sec over last 15 minutes |
+| `starlink_dish_pop_ping_drop_ratio`                 | Starlink PoP ping drop ratio                                                  |
+| `starlink_dish_pop_ping_latency_seconds`            | Starlink PoP ping latency in seconds                                          |
+| `starlink_dish_pop_ping_latency_seconds_histogram`  | Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes   |
+| `starlink_dish_software_update_state`               | Starlink dish update state                                                    |
+| `starlink_dish_software_update_reboot_ready`        | Whether the Starlink dish is ready to reboot to apply a software update       |
+| `starlink_dish_gps_valid`                           | Whether the Starlink dish GPS is valid                                        |
+| `starlink_dish_gps_satellites`                      | Number of GPS satellites visible to the Starlink dish                         |
+| `starlink_dish_tilt_angle_deg`                      | Starlink dish tilt angle degrees                                              |
+| `starlink_dish_boresight_azimuth_deg`               | Starlink dish boresight azimuth degrees                                       |
+| `starlink_dish_boresight_elevation_deg`             | Starlink dish boresight elevation degrees                                     |
+| `starlink_dish_desired_boresight_azimuth_deg`       | Starlink dish desired boresight azimuth degrees                               |
+| `starlink_dish_desired_boresight_elevation_deg`     | Starlink dish desired boresight elevation degrees                             |
+| `starlink_dish_currently_obstructed`                | Whether the Starlink dish is currently obstructed                             |
+| `starlink_dish_fraction_obstruction_ratio`          | Fraction of Starlink dish that is obstructed                                  |
+| `starlink_dish_last_24h_obstructed_seconds`         | Number of seconds the Starlink dish was obstructed in the past 24 hours       |
+| `starlink_dish_power_input_watts_histogram`         | Histogram of Starlink dish power input in watts over last 15 minutes          |
+| `starlink_dish_power_input_watts`                   | Current power input for the Starlink dish                                     |
+| `starlink_dish_power_watts`                         | Real-time Starlink dish power draw in watts, by power supply                  |
+| `starlink_dish_router_power_watts`                  | Real-time Starlink WiFi router power draw in watts                            |
+| `starlink_dish_upsu_uptime_seconds`                 | Starlink UPSU power supply uptime in seconds                                  |
+| `starlink_dish_thermal_throttle_level`              | Starlink dish thermal throttle level (0 is unthrottled)                       |
+| `starlink_dish_high_power_test_mode`                | Whether Starlink dish max-power test mode is active                           |
+| `starlink_dish_outage_cause`                        | Current Starlink dish outage cause, as its enum value                         |
+| `starlink_dish_location_info`                       | Dish location information                                                     |
+| `starlink_dish_location_latitude_deg`               | Location latitude in degrees                                                  |
+| `starlink_dish_location_longitude_deg`              | Location longitude in degrees                                                 |
+| `starlink_dish_location_altitude_meters`            | Location altitude in meters above sea level                                   |
+| `starlink_dish_alert_unexpected_location`           | Whether the Starlink dish is in an unexpected location                        |
+| `starlink_dish_alert_install_pending`               | Whether a Starlink Dish software update is pending installation               |
+| `starlink_dish_alert_is_heating`                    | Whether the Starlink dish is heating (snow melting)                           |
+| `starlink_dish_alert_is_power_save_idle`            | Whether the Starlink dish is currently in power saving mode                   |
+| `starlink_dish_alert_signal_lower_than_predicted`   | Whether the Starlink dish signal is lower than predicted                      |
+| `starlink_dish_alert_thermal_throttle`              | Whether the Starlink dish is throttling back due to heat                      |
+| `starlink_dish_alert_thermal_shutdown`              | Whether the Starlink dish has shut down due to heat                           |
+| `starlink_dish_alert_power_supply_thermal_throttle` | Whether the Starlink dish power supply is throttling back due to heat         |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Metrics are exposed at `/metrics` in the Prometheus text format.
 | `starlink_dish_up`                                 | Whether scraping metrics from the Starlink dish was successful                |
 | `starlink_dish_info`                               | Starlink dish software information                                            |
 | `starlink_dish_uptime_seconds`                     | Starlink dish uptime in seconds                                               |
+| `starlink_dish_mobility_class`                     | Starlink dish mobility class                                                  |
 | `starlink_dish_snr_above_noise_floor`              | Whether Starlink dish signal-to-noise ratio is above noise floor              |
 | `starlink_dish_snr_persistently_low`               | Whether Starlink dish signal-to-noise ratio is persistently low               |
 | `starlink_dish_uplink_throughput_bps`              | Starlink dish uplink throughput in bits/sec                                   |
@@ -55,6 +56,7 @@ Metrics are exposed at `/metrics` in the Prometheus text format.
 | `starlink_dish_pop_ping_drop_ratio`                | Starlink PoP ping drop ratio                                                  |
 | `starlink_dish_pop_ping_latency_seconds`           | Starlink PoP ping latency in seconds                                          |
 | `starlink_dish_pop_ping_latency_seconds_histogram` | Histogram of Starlink dish PoP ping latency in seconds over last 15 minutes   |
+| `starlink_dish_software_update_state`              | Starlink dish update state                                                    |
 | `starlink_dish_software_update_reboot_ready`       | Whether the Starlink dish is ready to reboot to apply a software update       |
 | `starlink_dish_gps_valid`                          | Whether the Starlink dish GPS is valid                                        |
 | `starlink_dish_gps_satellites`                     | Number of GPS satellites visible to the Starlink dish                         |
@@ -68,6 +70,11 @@ Metrics are exposed at `/metrics` in the Prometheus text format.
 | `starlink_dish_last_24h_obstructed_seconds`        | Number of seconds the Starlink dish was obstructed in the past 24 hours       |
 | `starlink_dish_power_input_watts_histogram`        | Histogram of Starlink dish power input in watts over last 15 minutes          |
 | `starlink_dish_power_input_watts`                  | Current power input for the Starlink dish                                     |
+| `starlink_dish_power_watts`                        | Real-time Starlink dish power draw in watts, by power supply                  |
+| `starlink_dish_router_power_watts`                 | Real-time Starlink WiFi router power draw in watts                            |
+| `starlink_dish_upsu_uptime_seconds`                | Starlink UPSU power supply uptime in seconds                                  |
+| `starlink_dish_thermal_throttle_level`             | Starlink dish thermal throttle level (0 is unthrottled)                       |
+| `starlink_dish_high_power_test_mode`               | Whether Starlink dish max-power test mode is active                           |
 | `starlink_dish_location_info`                      | Dish location information                                                     |
 | `starlink_dish_location_latitude_deg`              | Location latitude in degrees                                                  |
 | `starlink_dish_location_longitude_deg`             | Location longitude in degrees                                                 |

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -157,6 +157,37 @@ var (
 		Name:      "power_input_watts",
 		Help:      "Current power input for the Starlink dish",
 	}
+	dishPowerWatts = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "power_watts",
+		Help:      "Real-time Starlink dish power draw in watts, by power supply",
+		Labels:    []string{"supply"},
+	}
+	dishRouterPowerWatts = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "router_power_watts",
+		Help:      "Real-time Starlink WiFi router power draw in watts",
+	}
+	dishUpsuUptimeSeconds = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "upsu_uptime_seconds",
+		Help:      "Starlink UPSU power supply uptime in seconds",
+	}
+	dishThermalThrottleLevel = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "thermal_throttle_level",
+		Help:      "Starlink dish thermal throttle level (0 is unthrottled)",
+	}
+	dishHighPowerTestMode = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "high_power_test_mode",
+		Help:      "Whether Starlink dish max-power test mode is active",
+	}
 
 	// Software update
 	dishSoftwareUpdateState = &Desc{
@@ -331,6 +362,11 @@ var Descs = []*Desc{
 	dishLast24HoursObstructedSeconds,
 	dishPowerInputHistogram,
 	dishPowerInput,
+	dishPowerWatts,
+	dishRouterPowerWatts,
+	dishUpsuUptimeSeconds,
+	dishThermalThrottleLevel,
+	dishHighPowerTestMode,
 	dishLocationInfo,
 	dishLocationLatitude,
 	dishLocationLongitude,

--- a/internal/exporter/desc.go
+++ b/internal/exporter/desc.go
@@ -189,6 +189,15 @@ var (
 		Help:      "Whether Starlink dish max-power test mode is active",
 	}
 
+	// Outage
+	dishOutageCause = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "outage_cause",
+		Help:      "Current Starlink dish outage cause, as its enum value",
+		Labels:    []string{"cause"},
+	}
+
 	// Software update
 	dishSoftwareUpdateState = &Desc{
 		Namespace: namespace,
@@ -329,6 +338,24 @@ var (
 		Name:      "alert_signal_lower_than_predicted",
 		Help:      "Whether the Starlink dish signal is lower than predicted",
 	}
+	dishAlertThermalThrottle = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_thermal_throttle",
+		Help:      "Whether the Starlink dish is throttling back due to heat",
+	}
+	dishAlertThermalShutdown = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_thermal_shutdown",
+		Help:      "Whether the Starlink dish has shut down due to heat",
+	}
+	dishAlertPowerSupplyThermalThrottle = &Desc{
+		Namespace: namespace,
+		Subsystem: dishSubsystem,
+		Name:      "alert_power_supply_thermal_throttle",
+		Help:      "Whether the Starlink dish power supply is throttling back due to heat",
+	}
 )
 
 // Descs contains all Prometheus metrics descriptors for the exporter.
@@ -367,6 +394,7 @@ var Descs = []*Desc{
 	dishUpsuUptimeSeconds,
 	dishThermalThrottleLevel,
 	dishHighPowerTestMode,
+	dishOutageCause,
 	dishLocationInfo,
 	dishLocationLatitude,
 	dishLocationLongitude,
@@ -376,6 +404,9 @@ var Descs = []*Desc{
 	dishAlertIsHeating,
 	dishAlertIsPowerSaveIdle,
 	dishAlertSignalLowerThanPredicted,
+	dishAlertThermalThrottle,
+	dishAlertThermalShutdown,
+	dishAlertPowerSupplyThermalThrottle,
 }
 
 // Desc is a utility wrapper for prometheus.Desc.

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -201,6 +201,28 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 	ch <- metric(dishLast24HoursObstructedSeconds, prometheus.GaugeValue,
 		obstructionStats.GetTimeObstructed())
 
+	// starlink_dish_power_watts
+	ch <- metric(dishPowerWatts, prometheus.GaugeValue,
+		dishStatus.GetUpsuStats().GetDishPower(), "upsu")
+	ch <- metric(dishPowerWatts, prometheus.GaugeValue,
+		dishStatus.GetApsStats().GetDishPower(), "aps")
+
+	// starlink_dish_router_power_watts
+	ch <- metric(dishRouterPowerWatts, prometheus.GaugeValue,
+		dishStatus.GetUpsuStats().GetRouterPower())
+
+	// starlink_dish_upsu_uptime_seconds
+	ch <- metric(dishUpsuUptimeSeconds, prometheus.GaugeValue,
+		dishStatus.GetUpsuStats().GetUptime())
+
+	// starlink_dish_thermal_throttle_level
+	ch <- metric(dishThermalThrottleLevel, prometheus.GaugeValue,
+		dishStatus.GetPlcStats().GetThermalThrottleLevel())
+
+	// starlink_dish_high_power_test_mode
+	ch <- metric(dishHighPowerTestMode, prometheus.GaugeValue,
+		btof(dishStatus.GetHighPowerTestMode()))
+
 	// starlink_dish_alert_unexpected_location
 	ch <- metric(dishAlertUnexpectedLocation, prometheus.GaugeValue,
 		btof(alerts.GetUnexpectedLocation()))

--- a/internal/exporter/scrape.go
+++ b/internal/exporter/scrape.go
@@ -223,6 +223,11 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 	ch <- metric(dishHighPowerTestMode, prometheus.GaugeValue,
 		btof(dishStatus.GetHighPowerTestMode()))
 
+	// starlink_dish_outage_cause
+	outage := dishStatus.GetOutage()
+	ch <- metric(dishOutageCause, prometheus.GaugeValue,
+		outage.GetCause(), outage.GetCause().String())
+
 	// starlink_dish_alert_unexpected_location
 	ch <- metric(dishAlertUnexpectedLocation, prometheus.GaugeValue,
 		btof(alerts.GetUnexpectedLocation()))
@@ -242,6 +247,18 @@ func (e *Exporter) scrapeDishStatus(ctx context.Context, ch chan<- prometheus.Me
 	// starlink_dish_alert_lower_than_predicted
 	ch <- metric(dishAlertSignalLowerThanPredicted, prometheus.GaugeValue,
 		btof(alerts.GetLowerSignalThanPredicted()))
+
+	// starlink_dish_alert_thermal_throttle
+	ch <- metric(dishAlertThermalThrottle, prometheus.GaugeValue,
+		btof(alerts.GetThermalThrottle()))
+
+	// starlink_dish_alert_thermal_shutdown
+	ch <- metric(dishAlertThermalShutdown, prometheus.GaugeValue,
+		btof(alerts.GetThermalShutdown()))
+
+	// starlink_dish_alert_power_supply_thermal_throttle
+	ch <- metric(dishAlertPowerSupplyThermalThrottle, prometheus.GaugeValue,
+		btof(alerts.GetPowerSupplyThermalThrottle()))
 
 	return true
 }


### PR DESCRIPTION
Adds real-time power, thermal and outage metrics from the `get_status` response, complementing the existing 15-minute `power_in` history metrics:

| Metric | Source |
|--------|--------|
| `starlink_dish_power_watts{supply="upsu"\|"aps"}` | `upsu_stats.dish_power` / `aps_stats.dish_power` |
| `starlink_dish_router_power_watts` | `upsu_stats.router_power` |
| `starlink_dish_upsu_uptime_seconds` | `upsu_stats.uptime` |
| `starlink_dish_thermal_throttle_level` | `plc_stats.thermal_throttle_level` |
| `starlink_dish_high_power_test_mode` | `high_power_test_mode` |
| `starlink_dish_outage_cause{cause}` | `outage.cause` (value is the enum, label is its name) |
| `starlink_dish_alert_thermal_throttle` | `alerts.thermal_throttle` |
| `starlink_dish_alert_thermal_shutdown` | `alerts.thermal_shutdown` |
| `starlink_dish_alert_power_supply_thermal_throttle` | `alerts.power_supply_thermal_throttle` |

Also regenerates the README metrics table via `scripts/gen-metrics`, which picks up the previously missing `starlink_dish_mobility_class` and `starlink_dish_software_update_state` rows.

`golangci-lint run` and `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)